### PR TITLE
feat(home): add Hero with positioning, CTAs and trust highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,15 +19,37 @@
       </div>
     </header>
     <main>
-      <section class="bg-gradient-to-b from-indigo-50 to-white">
-        <div class="mx-auto max-w-7xl px-6 py-24 text-center">
-          <h1 class="text-4xl font-extrabold tracking-tight sm:text-6xl">Precision Location Intelligence</h1>
-          <p class="mx-auto mt-6 max-w-2xl text-lg text-gray-600">
-            GeoFidelity delivers real-time geospatial insights so you can make smarter, faster decisions.
-          </p>
-          <div class="mt-8 flex justify-center gap-4">
-            <a href="#contact" class="rounded-md bg-indigo-600 px-6 py-3 font-medium text-white hover:bg-indigo-500">Get Started</a>
-            <a href="#features" class="rounded-md bg-white px-6 py-3 font-medium text-indigo-600 shadow-sm ring-1 ring-indigo-600 hover:bg-indigo-50">Learn More</a>
+      <section class="bg-white">
+        <div class="mx-auto max-w-7xl px-6 py-24 md:grid md:grid-cols-2 md:items-center md:gap-12">
+          <div>
+            <p class="text-sm font-semibold uppercase tracking-wide text-indigo-600">Map accuracy &amp; verification</p>
+            <h1 class="mt-4 text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl">Verified maps. Trusted places.</h1>
+            <p class="mt-6 text-lg text-gray-600">
+              Geofidelity fixes and enhances OpenStreetMap (and the maps you rely on) so your site is findable, navigable, and correctly represented. Ideal for national parks, trusts, forestry estates, and new-build developments.
+            </p>
+            <div class="mt-8 flex flex-col gap-4 sm:flex-row">
+              <a href="/contact" class="rounded-md bg-indigo-600 px-6 py-3 text-center font-medium text-white hover:bg-indigo-500">Request a Map Readiness Audit</a>
+              <a href="#process" class="px-6 py-3 text-center font-medium text-indigo-600 hover:underline">How it works</a>
+            </div>
+            <ul class="mt-8 flex flex-col gap-3 text-sm text-gray-700 sm:flex-row sm:items-center sm:gap-6">
+              <li class="flex items-center gap-2">
+                <svg class="h-4 w-4 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+                <span>OSM-compliant editing</span>
+              </li>
+              <li class="flex items-center gap-2">
+                <svg class="h-4 w-4 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+                <span>Open data, properly attributed</span>
+              </li>
+              <li class="flex items-center gap-2">
+                <svg class="h-4 w-4 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+                <span>Cross-platform visibility</span>
+              </li>
+            </ul>
+          </div>
+          <div class="mt-12 md:mt-0">
+            <svg class="h-auto w-full" role="img" aria-label="Illustration: map layers aligning" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+              <rect width="400" height="300" fill="#e5e7eb" />
+            </svg>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- implement redesigned hero section with updated message and CTA links
- include trust highlight row and illustrative placeholder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b31bffebb083248eabc4e6da1dda06