### PR TITLE
feat(home): add value propositions grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,51 @@
           </div>
         </div>
       </section>
+      <section aria-labelledby="outcomes-heading" class="bg-gray-50 py-24">
+        <div class="mx-auto max-w-7xl px-6">
+          <h2 id="outcomes-heading" class="text-center text-3xl font-bold text-gray-900">
+            Outcomes that matter
+          </h2>
+          <div class="mt-12 grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M5 13l4 4L19 7" />
+              </svg>
+              <h3 class="mt-4 text-xl font-semibold text-gray-900">Findability &amp; discoverability</h3>
+              <p class="mt-2 text-gray-600">
+                Appear correctly across OSM, Google and Apple so people can actually find you.
+              </p>
+            </div>
+            <div>
+              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M5 13l4 4L19 7" />
+              </svg>
+              <h3 class="mt-4 text-xl font-semibold text-gray-900">Navigation that works</h3>
+              <p class="mt-2 text-gray-600">
+                Correct paths and entrances reduce wrong turns, complaints and wasted time.
+              </p>
+            </div>
+            <div>
+              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M5 13l4 4L19 7" />
+              </svg>
+              <h3 class="mt-4 text-xl font-semibold text-gray-900">Visitor experience &amp; safety</h3>
+              <p class="mt-2 text-gray-600">
+                Reliable trail and amenity data builds trust and improves outcomes.
+              </p>
+            </div>
+            <div>
+              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M5 13l4 4L19 7" />
+              </svg>
+              <h3 class="mt-4 text-xl font-semibold text-gray-900">Ongoing assurance</h3>
+              <p class="mt-2 text-gray-600">
+                Stay in sync with on-the-ground changes via simple maintenance plans.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
       <section aria-labelledby="impact-heading" class="bg-gray-50 py-24">
         <div class="mx-auto max-w-7xl px-6">
           <h2 id="impact-heading" class="sr-only">Before and After Map Impact</h2>


### PR DESCRIPTION
## Summary
- add responsive "Outcomes that matter" section with four value propositions on home page

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b321995cd88324a91f109b1b5c0019