### PR TITLE
feat(home): add Services teaser cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,28 @@
           </div>
         </div>
       </section>
+      <section aria-labelledby="services-heading" class="bg-gray-50 py-24">
+        <div class="mx-auto max-w-7xl px-6">
+          <h2 id="services-heading" class="text-3xl font-bold text-gray-900">Services</h2>
+          <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <h3 class="text-xl font-semibold text-gray-900">Map Readiness Audit</h3>
+              <p class="mt-2 text-gray-600">Cross-platform review of your site’s presence with a fix plan.</p>
+              <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
+            </a>
+            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <h3 class="text-xl font-semibold text-gray-900">OSM Enhancements</h3>
+              <p class="mt-2 text-gray-600">Compliant edits, imports and QA to align maps with reality.</p>
+              <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
+            </a>
+            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <h3 class="text-xl font-semibold text-gray-900">Field Survey Add-on</h3>
+              <p class="mt-2 text-gray-600">On-site verification; GNSS, trails and entrances. Drone imagery available.</p>
+              <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
+            </a>
+          </div>
+        </div>
+      </section>
       <section aria-labelledby="outcomes-heading" class="bg-gray-50 py-24">
         <div class="mx-auto max-w-7xl px-6">
           <h2 id="outcomes-heading" class="text-center text-3xl font-bold text-gray-900">


### PR DESCRIPTION
## Summary
- add Services teaser cards on home page linking to /services

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b323f27c2c8324857aa6c1168978ce