### PR TITLE
fix(a11y): improve focus states and labelling on home

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GeoFidelity</title>
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <style>
+      a:focus-visible,
+      button:focus-visible {
+        outline: 2px solid #4f46e5;
+        outline-offset: 2px;
+      }
+    </style>
   </head>
   <body class="bg-gray-50 text-gray-900 antialiased">
     <header class="bg-white shadow">
@@ -32,15 +39,15 @@
             </div>
             <ul class="mt-8 flex flex-col gap-3 text-sm text-gray-700 sm:flex-row sm:items-center sm:gap-6">
               <li class="flex items-center gap-2">
-                <svg class="h-4 w-4 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+                <svg class="h-4 w-4 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
                 <span>OSM-compliant editing</span>
               </li>
               <li class="flex items-center gap-2">
-                <svg class="h-4 w-4 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+                <svg class="h-4 w-4 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
                 <span>Open data, properly attributed</span>
               </li>
               <li class="flex items-center gap-2">
-                <svg class="h-4 w-4 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+                <svg class="h-4 w-4 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
                 <span>Cross-platform visibility</span>
               </li>
             </ul>
@@ -54,7 +61,7 @@
       </section>
       <section class="bg-gray-900 text-white">
         <div class="mx-auto flex max-w-7xl items-center justify-center px-6 py-4 text-sm">
-          <svg class="mr-2 h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg class="mr-2 h-5 w-5" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
             <path d="M9 12l2 2 4-4"/>
           </svg>
@@ -116,17 +123,17 @@
         <div class="mx-auto max-w-7xl px-6">
           <h2 id="services-heading" class="text-3xl font-bold text-gray-900">Services</h2>
           <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
               <h3 class="text-xl font-semibold text-gray-900">Map Readiness Audit</h3>
               <p class="mt-2 text-gray-600">Cross-platform review of your site’s presence with a fix plan.</p>
               <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
             </a>
-            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
               <h3 class="text-xl font-semibold text-gray-900">OSM Enhancements</h3>
               <p class="mt-2 text-gray-600">Compliant edits, imports and QA to align maps with reality.</p>
               <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
             </a>
-            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
               <h3 class="text-xl font-semibold text-gray-900">Field Survey Add-on</h3>
               <p class="mt-2 text-gray-600">On-site verification; GNSS, trails and entrances. Drone imagery available.</p>
               <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
@@ -141,7 +148,7 @@
           </h2>
           <div class="mt-12 grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-4">
             <div>
-              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M5 13l4 4L19 7" />
               </svg>
               <h3 class="mt-4 text-xl font-semibold text-gray-900">Findability &amp; discoverability</h3>
@@ -150,7 +157,7 @@
               </p>
             </div>
             <div>
-              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M5 13l4 4L19 7" />
               </svg>
               <h3 class="mt-4 text-xl font-semibold text-gray-900">Navigation that works</h3>
@@ -159,7 +166,7 @@
               </p>
             </div>
             <div>
-              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M5 13l4 4L19 7" />
               </svg>
               <h3 class="mt-4 text-xl font-semibold text-gray-900">Visitor experience &amp; safety</h3>
@@ -168,7 +175,7 @@
               </p>
             </div>
             <div>
-              <svg class="h-8 w-8 text-indigo-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M5 13l4 4L19 7" />
               </svg>
               <h3 class="mt-4 text-xl font-semibold text-gray-900">Ongoing assurance</h3>
@@ -184,7 +191,7 @@
           <h2 id="impact-heading" class="sr-only">Before and After Map Impact</h2>
           <div class="grid gap-8 md:grid-cols-2">
             <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-              <svg class="h-8 w-8 text-gray-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
                 <circle cx="12" cy="10" r="3"/>
               </svg>
@@ -192,7 +199,7 @@
               <p class="mt-2 text-gray-600">Missing paths, mis-pinned entrances, stale POIs. Visitors and deliveries struggle.</p>
             </div>
             <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-              <svg class="h-8 w-8 text-gray-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
                 <circle cx="12" cy="10" r="3"/>
               </svg>


### PR DESCRIPTION
## Summary
- add global focus-visible outlines for buttons and links
- hide decorative SVG icons from assistive tech
- tidy services cards' focus styles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b32bf5bea88324a2d279f29edea23f