### PR TITLE
Reorder landing page sections for better flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,147 +68,147 @@
           <span>Transparent, OSM-compliant editing with proper attribution and documented sources.</span>
         </div>
       </section>
-      <section id="process" aria-labelledby="process-heading" class="bg-white py-24">
-        <div class="mx-auto max-w-7xl px-6">
-          <h2 id="process-heading" class="text-3xl font-bold text-gray-900">How it works</h2>
-          <ol class="mt-12 space-y-8 md:flex md:space-y-0 md:space-x-12">
-            <li class="flex items-start gap-4">
-              <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white" aria-label="Step 1">1</div>
+        <section aria-labelledby="outcomes-heading" class="bg-gray-50 py-24">
+          <div class="mx-auto max-w-7xl px-6">
+            <h2 id="outcomes-heading" class="text-center text-3xl font-bold text-gray-900">
+              Outcomes that matter
+            </h2>
+            <div class="mt-12 grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-4">
               <div>
-                <h3 class="text-xl font-semibold">Audit</h3>
-                <p class="mt-2 text-gray-600">We review OSM, Google and Apple for gaps, errors and opportunities.</p>
+                <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 13l4 4L19 7" />
+                </svg>
+                <h3 class="mt-4 text-xl font-semibold text-gray-900">Findability &amp; discoverability</h3>
+                <p class="mt-2 text-gray-600">
+                  Appear correctly across OSM, Google and Apple so people can actually find you.
+                </p>
               </div>
-            </li>
-            <li class="flex items-start gap-4">
-              <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white" aria-label="Step 2">2</div>
               <div>
-                <h3 class="text-xl font-semibold">Fix &amp; verify</h3>
-                <p class="mt-2 text-gray-600">We make compliant OSM edits and submit platform updates where appropriate.</p>
+                <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 13l4 4L19 7" />
+                </svg>
+                <h3 class="mt-4 text-xl font-semibold text-gray-900">Navigation that works</h3>
+                <p class="mt-2 text-gray-600">
+                  Correct paths and entrances reduce wrong turns, complaints and wasted time.
+                </p>
               </div>
-            </li>
-            <li class="flex items-start gap-4">
-              <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white" aria-label="Step 3">3</div>
               <div>
-                <h3 class="text-xl font-semibold">Maintain</h3>
-                <p class="mt-2 text-gray-600">Optional retainer to keep your area in sync with on-the-ground changes.</p>
+                <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 13l4 4L19 7" />
+                </svg>
+                <h3 class="mt-4 text-xl font-semibold text-gray-900">Visitor experience &amp; safety</h3>
+                <p class="mt-2 text-gray-600">
+                  Reliable trail and amenity data builds trust and improves outcomes.
+                </p>
               </div>
-            </li>
-          </ol>
-        </div>
-      </section>
-      <section aria-labelledby="customers-heading" class="bg-white py-24">
-        <div class="mx-auto max-w-7xl px-6">
-          <h2 id="customers-heading" class="text-3xl font-bold text-gray-900">Built for places that welcome people</h2>
-          <ul class="mt-8 flex flex-wrap gap-8">
-            <li class="flex-1 min-w-[250px]">
-              <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">National parks &amp; trusts</p>
-              <p class="mt-2 text-sm text-gray-600">Trails, car parks, amenities and access.</p>
-            </li>
-            <li class="flex-1 min-w-[250px]">
-              <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">Forestry estates</p>
-              <p class="mt-2 text-sm text-gray-600">Shared use trails and seasonal restrictions.</p>
-            </li>
-            <li class="flex-1 min-w-[250px]">
-              <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">New-build developments</p>
-              <p class="mt-2 text-sm text-gray-600">Addresses, road layout and entrances mapped correctly.</p>
-            </li>
-            <li class="flex-1 min-w-[250px]">
-              <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">Commercial estates</p>
-              <p class="mt-2 text-sm text-gray-600">Signposted entrances, parking and tenant POIs.</p>
-            </li>
-          </ul>
-        </div>
-      </section>
-      <section aria-labelledby="services-heading" class="bg-gray-50 py-24">
-        <div class="mx-auto max-w-7xl px-6">
-          <h2 id="services-heading" class="text-3xl font-bold text-gray-900">Services</h2>
-          <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
-            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
-              <h3 class="text-xl font-semibold text-gray-900">Map Readiness Audit</h3>
-              <p class="mt-2 text-gray-600">Cross-platform review of your site’s presence with a fix plan.</p>
-              <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
-            </a>
-            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
-              <h3 class="text-xl font-semibold text-gray-900">OSM Enhancements</h3>
-              <p class="mt-2 text-gray-600">Compliant edits, imports and QA to align maps with reality.</p>
-              <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
-            </a>
-            <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
-              <h3 class="text-xl font-semibold text-gray-900">Field Survey Add-on</h3>
-              <p class="mt-2 text-gray-600">On-site verification; GNSS, trails and entrances. Drone imagery available.</p>
-              <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
-            </a>
-          </div>
-        </div>
-      </section>
-      <section aria-labelledby="outcomes-heading" class="bg-gray-50 py-24">
-        <div class="mx-auto max-w-7xl px-6">
-          <h2 id="outcomes-heading" class="text-center text-3xl font-bold text-gray-900">
-            Outcomes that matter
-          </h2>
-          <div class="mt-12 grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-4">
-            <div>
-              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 13l4 4L19 7" />
-              </svg>
-              <h3 class="mt-4 text-xl font-semibold text-gray-900">Findability &amp; discoverability</h3>
-              <p class="mt-2 text-gray-600">
-                Appear correctly across OSM, Google and Apple so people can actually find you.
-              </p>
-            </div>
-            <div>
-              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 13l4 4L19 7" />
-              </svg>
-              <h3 class="mt-4 text-xl font-semibold text-gray-900">Navigation that works</h3>
-              <p class="mt-2 text-gray-600">
-                Correct paths and entrances reduce wrong turns, complaints and wasted time.
-              </p>
-            </div>
-            <div>
-              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 13l4 4L19 7" />
-              </svg>
-              <h3 class="mt-4 text-xl font-semibold text-gray-900">Visitor experience &amp; safety</h3>
-              <p class="mt-2 text-gray-600">
-                Reliable trail and amenity data builds trust and improves outcomes.
-              </p>
-            </div>
-            <div>
-              <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 13l4 4L19 7" />
-              </svg>
-              <h3 class="mt-4 text-xl font-semibold text-gray-900">Ongoing assurance</h3>
-              <p class="mt-2 text-gray-600">
-                Stay in sync with on-the-ground changes via simple maintenance plans.
-              </p>
+              <div>
+                <svg class="h-8 w-8 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 13l4 4L19 7" />
+                </svg>
+                <h3 class="mt-4 text-xl font-semibold text-gray-900">Ongoing assurance</h3>
+                <p class="mt-2 text-gray-600">
+                  Stay in sync with on-the-ground changes via simple maintenance plans.
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-      </section>
-      <section aria-labelledby="impact-heading" class="bg-gray-50 py-24">
-        <div class="mx-auto max-w-7xl px-6">
-          <h2 id="impact-heading" class="sr-only">Before and After Map Impact</h2>
-          <div class="grid gap-8 md:grid-cols-2">
-            <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-              <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
-                <circle cx="12" cy="10" r="3"/>
-              </svg>
-              <h3 class="mt-4 text-xl font-semibold">Before</h3>
-              <p class="mt-2 text-gray-600">Missing paths, mis-pinned entrances, stale POIs. Visitors and deliveries struggle.</p>
-            </div>
-            <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-              <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
-                <circle cx="12" cy="10" r="3"/>
-              </svg>
-              <h3 class="mt-4 text-xl font-semibold">After</h3>
-              <p class="mt-2 text-gray-600">Correct trails, entrances, and amenities. Better routes, fewer mistakes, happier visitors.</p>
+        </section>
+        <section aria-labelledby="impact-heading" class="bg-gray-50 py-24">
+          <div class="mx-auto max-w-7xl px-6">
+            <h2 id="impact-heading" class="sr-only">Before and After Map Impact</h2>
+            <div class="grid gap-8 md:grid-cols-2">
+              <div class="flex flex-col rounded-lg bg-white p-6 shadow">
+                <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
+                  <circle cx="12" cy="10" r="3"/>
+                </svg>
+                <h3 class="mt-4 text-xl font-semibold">Before</h3>
+                <p class="mt-2 text-gray-600">Missing paths, mis-pinned entrances, stale POIs. Visitors and deliveries struggle.</p>
+              </div>
+              <div class="flex flex-col rounded-lg bg-white p-6 shadow">
+                <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
+                  <circle cx="12" cy="10" r="3"/>
+                </svg>
+                <h3 class="mt-4 text-xl font-semibold">After</h3>
+                <p class="mt-2 text-gray-600">Correct trails, entrances, and amenities. Better routes, fewer mistakes, happier visitors.</p>
+              </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
+        <section aria-labelledby="services-heading" class="bg-gray-50 py-24">
+          <div class="mx-auto max-w-7xl px-6">
+            <h2 id="services-heading" class="text-3xl font-bold text-gray-900">Services</h2>
+            <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+              <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
+                <h3 class="text-xl font-semibold text-gray-900">Map Readiness Audit</h3>
+                <p class="mt-2 text-gray-600">Cross-platform review of your site’s presence with a fix plan.</p>
+                <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
+              </a>
+              <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
+                <h3 class="text-xl font-semibold text-gray-900">OSM Enhancements</h3>
+                <p class="mt-2 text-gray-600">Compliant edits, imports and QA to align maps with reality.</p>
+                <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
+              </a>
+              <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
+                <h3 class="text-xl font-semibold text-gray-900">Field Survey Add-on</h3>
+                <p class="mt-2 text-gray-600">On-site verification; GNSS, trails and entrances. Drone imagery available.</p>
+                <span class="mt-4 inline-flex items-center text-indigo-600">Learn more<span aria-hidden="true" class="ml-1">→</span></span>
+              </a>
+            </div>
+          </div>
+        </section>
+        <section id="process" aria-labelledby="process-heading" class="bg-white py-24">
+          <div class="mx-auto max-w-7xl px-6">
+            <h2 id="process-heading" class="text-3xl font-bold text-gray-900">How it works</h2>
+            <ol class="mt-12 space-y-8 md:flex md:space-y-0 md:space-x-12">
+              <li class="flex items-start gap-4">
+                <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white" aria-label="Step 1">1</div>
+                <div>
+                  <h3 class="text-xl font-semibold">Audit</h3>
+                  <p class="mt-2 text-gray-600">We review OSM, Google and Apple for gaps, errors and opportunities.</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-4">
+                <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white" aria-label="Step 2">2</div>
+                <div>
+                  <h3 class="text-xl font-semibold">Fix &amp; verify</h3>
+                  <p class="mt-2 text-gray-600">We make compliant OSM edits and submit platform updates where appropriate.</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-4">
+                <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white" aria-label="Step 3">3</div>
+                <div>
+                  <h3 class="text-xl font-semibold">Maintain</h3>
+                  <p class="mt-2 text-gray-600">Optional retainer to keep your area in sync with on-the-ground changes.</p>
+                </div>
+              </li>
+            </ol>
+          </div>
+        </section>
+        <section aria-labelledby="customers-heading" class="bg-white py-24">
+          <div class="mx-auto max-w-7xl px-6">
+            <h2 id="customers-heading" class="text-3xl font-bold text-gray-900">Built for places that welcome people</h2>
+            <ul class="mt-8 flex flex-wrap gap-8">
+              <li class="flex-1 min-w-[250px]">
+                <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">National parks &amp; trusts</p>
+                <p class="mt-2 text-sm text-gray-600">Trails, car parks, amenities and access.</p>
+              </li>
+              <li class="flex-1 min-w-[250px]">
+                <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">Forestry estates</p>
+                <p class="mt-2 text-sm text-gray-600">Shared use trails and seasonal restrictions.</p>
+              </li>
+              <li class="flex-1 min-w-[250px]">
+                <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">New-build developments</p>
+                <p class="mt-2 text-sm text-gray-600">Addresses, road layout and entrances mapped correctly.</p>
+              </li>
+              <li class="flex-1 min-w-[250px]">
+                <p class="inline-block rounded-full bg-indigo-100 px-3 py-1 text-sm font-medium text-indigo-700">Commercial estates</p>
+                <p class="mt-2 text-sm text-gray-600">Signposted entrances, parking and tenant POIs.</p>
+              </li>
+            </ul>
+          </div>
+        </section>
       <section id="about" class="bg-gray-50 py-24">
         <div class="mx-auto max-w-3xl px-6 text-center">
           <h2 class="text-3xl font-bold">About GeoFidelity</h2>


### PR DESCRIPTION
## Summary
- Reorder landing page sections so visitors see outcomes and case-study impact before service details
- Move services, process, and customer audience sections to a more logical sequence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b32d4194fc832488a9195c4ce91424