### PR TITLE
feat: add mobile navigation and section anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,11 +17,52 @@
     <header class="bg-white shadow">
       <div class="mx-auto flex max-w-7xl items-center justify-between px-6 py-6">
         <a href="#" class="text-2xl font-bold text-indigo-600">GeoFidelity</a>
-        <nav class="hidden gap-8 text-sm md:flex">
+        <button
+          id="menu-button"
+          type="button"
+          class="rounded-md p-2 text-gray-600 focus:outline-none md:hidden"
+          aria-controls="mobile-menu"
+          aria-expanded="false"
+        >
+          <span class="sr-only">Open main menu</span>
+          <svg
+            class="h-6 w-6"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <nav class="hidden gap-8 text-sm md:flex" id="desktop-menu">
+          <a href="#outcomes" class="text-gray-600 hover:text-gray-900">Outcomes</a>
+          <a href="#process" class="text-gray-600 hover:text-gray-900">Process</a>
+          <a href="#customers" class="text-gray-600 hover:text-gray-900">Customers</a>
           <a href="#about" class="text-gray-600 hover:text-gray-900">About</a>
           <a href="#contact" class="text-gray-600 hover:text-gray-900">Contact</a>
         </nav>
-        <a href="#contact" class="rounded-md bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500">Request Demo</a>
+        <a
+          href="#contact"
+          class="hidden rounded-md bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500 md:block"
+          >Request Demo</a
+        >
+      </div>
+      <div id="mobile-menu" class="hidden border-t border-gray-200 px-6 pb-4 md:hidden">
+        <nav class="flex flex-col gap-2 pt-4 text-sm">
+          <a href="#outcomes" class="text-gray-600 hover:text-gray-900">Outcomes</a>
+          <a href="#process" class="text-gray-600 hover:text-gray-900">Process</a>
+          <a href="#customers" class="text-gray-600 hover:text-gray-900">Customers</a>
+          <a href="#about" class="text-gray-600 hover:text-gray-900">About</a>
+          <a href="#contact" class="text-gray-600 hover:text-gray-900">Contact</a>
+          <a
+            href="#contact"
+            class="mt-2 rounded-md bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500"
+            >Request Demo</a
+          >
+        </nav>
       </div>
     </header>
     <main>
@@ -68,7 +109,7 @@
           <span>Transparent, OSM-compliant editing with proper attribution and documented sources.</span>
         </div>
       </section>
-        <section aria-labelledby="outcomes-heading" class="bg-gray-50 py-24">
+        <section id="outcomes" aria-labelledby="outcomes-heading" class="bg-gray-50 py-24">
           <div class="mx-auto max-w-7xl px-6">
             <h2 id="outcomes-heading" class="text-center text-3xl font-bold text-gray-900">
               Outcomes that matter
@@ -186,7 +227,7 @@
             </ol>
           </div>
         </section>
-        <section aria-labelledby="customers-heading" class="bg-white py-24">
+        <section id="customers" aria-labelledby="customers-heading" class="bg-white py-24">
           <div class="mx-auto max-w-7xl px-6">
             <h2 id="customers-heading" class="text-3xl font-bold text-gray-900">Built for places that welcome people</h2>
             <ul class="mt-8 flex flex-wrap gap-8">
@@ -253,6 +294,13 @@
     </footer>
     <script>
       document.getElementById('year').textContent = new Date().getFullYear();
+      const menuButton = document.getElementById('menu-button');
+      const mobileMenu = document.getElementById('mobile-menu');
+      menuButton.addEventListener('click', () => {
+        const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+        menuButton.setAttribute('aria-expanded', String(!expanded));
+        mobileMenu.classList.toggle('hidden');
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add mobile navigation menu toggle and desktop nav links
- link nav items to page sections and add missing section IDs
- include script for mobile menu toggle

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b347bf8cf483248d273a7f122fb469