### PR TITLE
Add SVG wordmark and integrate into header

### DIFF
--- a/geofidelity-wordmark.svg
+++ b/geofidelity-wordmark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" role="img" aria-labelledby="title">
+  <title id="title">GeoFidelity wordmark</title>
+  <text x="0" y="32" font-family="system-ui, sans-serif" font-size="32" fill="#4f46e5">
+    <tspan font-weight="700">Geo</tspan><tspan font-weight="300">Fidelity</tspan>
+  </text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
   <body class="bg-gray-50 text-gray-900 antialiased">
     <header class="bg-white shadow">
       <div class="mx-auto flex max-w-7xl items-center justify-between px-6 py-6">
-        <a href="#" class="text-2xl font-bold text-indigo-600">GeoFidelity</a>
+        <a href="#" class="block">
+          <img src="geofidelity-wordmark.svg" alt="GeoFidelity" class="h-8" />
+        </a>
         <button
           id="menu-button"
           type="button"


### PR DESCRIPTION
## Summary
- add SVG wordmark with bold "Geo" and light "Fidelity"
- use new SVG wordmark in site header for scalable branding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b46b5c4c248324b5e3589c204f6016