### PR TITLE
Tie section content fade-in to scroll position

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,18 +307,23 @@
       });
 
       gsap.registerPlugin(ScrollTrigger);
-      gsap.utils.toArray('section').forEach((section) => {
-        gsap.from(section, {
-          opacity: 0,
-          y: 50,
-          duration: 0.6,
-          ease: 'power1.out',
-          scrollTrigger: {
-            trigger: section,
-            start: 'top 80%',
-            toggleActions: 'play none none none',
-          },
-        });
+      gsap.utils.toArray('section:not(:first-of-type)').forEach((section) => {
+        const content = section.querySelector(':scope > *');
+        if (content) {
+          gsap.fromTo(
+            content,
+            { opacity: 0 },
+            {
+              opacity: 1,
+              scrollTrigger: {
+                trigger: section,
+                start: 'top 90%',
+                end: 'top 50%',
+                scrub: true,
+              },
+            }
+          );
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- Fade in section content on scroll using GSAP
- Exclude first section and bind animation to scroll between 90% and 50% viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4769b66248324a9d2269156dae14e