### PR TITLE
feat: full-screen mobile menu overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body class="bg-gray-50 text-gray-900 antialiased">
-    <header class="bg-white shadow">
+    <header class="fixed inset-x-0 top-0 z-50 bg-white shadow">
       <div class="mx-auto flex max-w-7xl items-center justify-between px-6 py-6">
         <a href="#" class="block">
           <img src="geofidelity-wordmark.svg" alt="GeoFidelity" class="h-8" />
@@ -30,6 +30,7 @@
         >
           <span class="sr-only">Open main menu</span>
           <svg
+            id="icon-menu"
             class="h-6 w-6"
             aria-hidden="true"
             fill="none"
@@ -39,6 +40,18 @@
             stroke-linejoin="round"
           >
             <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          <svg
+            id="icon-close"
+            class="hidden h-6 w-6"
+            aria-hidden="true"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M6 6l12 12M6 18L18 6" />
           </svg>
         </button>
         <nav class="hidden gap-8 text-sm md:flex" id="desktop-menu">
@@ -54,8 +67,11 @@
           >Request Demo</a
         >
       </div>
-      <div id="mobile-menu" class="hidden border-t border-gray-200 px-6 pb-4 md:hidden">
-        <nav class="flex flex-col gap-2 pt-4 text-sm">
+      <div
+        id="mobile-menu"
+        class="hidden fixed inset-0 z-40 bg-white p-6 md:hidden"
+      >
+        <nav class="flex h-full flex-col items-center justify-center gap-4 text-lg">
           <a href="#outcomes" class="text-gray-600 hover:text-gray-900">Outcomes</a>
           <a href="#process" class="text-gray-600 hover:text-gray-900">Process</a>
           <a href="#customers" class="text-gray-600 hover:text-gray-900">Customers</a>
@@ -63,13 +79,13 @@
           <a href="#contact" class="text-gray-600 hover:text-gray-900">Contact</a>
           <a
             href="#contact"
-            class="mt-2 rounded-md bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500"
+            class="rounded-md bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500"
             >Request Demo</a
           >
         </nav>
       </div>
     </header>
-    <main>
+    <main class="pt-24">
       <section class="bg-white">
         <div class="mx-auto max-w-7xl px-6 py-24 md:grid md:grid-cols-2 md:items-center md:gap-12">
           <div>
@@ -300,10 +316,15 @@
       document.getElementById('year').textContent = new Date().getFullYear();
       const menuButton = document.getElementById('menu-button');
       const mobileMenu = document.getElementById('mobile-menu');
+      const openIcon = document.getElementById('icon-menu');
+      const closeIcon = document.getElementById('icon-close');
       menuButton.addEventListener('click', () => {
         const expanded = menuButton.getAttribute('aria-expanded') === 'true';
         menuButton.setAttribute('aria-expanded', String(!expanded));
         mobileMenu.classList.toggle('hidden');
+        openIcon.classList.toggle('hidden');
+        closeIcon.classList.toggle('hidden');
+        document.body.classList.toggle('overflow-hidden');
       });
 
       gsap.registerPlugin(ScrollTrigger);


### PR DESCRIPTION
## Summary
- fix navigation bar to top across screen sizes
- add full-screen mobile menu overlay with toggleable hamburger/cross icon
- prevent background scrolling when menu is open

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b4823e1cd88324ad27792da3ee54f1