### PR TITLE
Fix inconsistent hover behavior in client tab selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -532,11 +532,26 @@
           tab.addEventListener('click', () => {
             if (tab.getAttribute('aria-selected') === 'true') return;
             tabs.forEach((t) => {
-              t.classList.remove('border-indigo-600', 'text-indigo-600', 'font-semibold');
-              t.classList.add('border-transparent', 'text-gray-600', 'font-normal');
+              t.classList.remove(
+                'border-indigo-600',
+                'text-indigo-600',
+                'font-semibold',
+                'hover:text-gray-900'
+              );
+              t.classList.add(
+                'border-transparent',
+                'text-gray-600',
+                'font-normal',
+                'hover:text-gray-900'
+              );
               t.setAttribute('aria-selected', 'false');
             });
-            tab.classList.remove('border-transparent', 'text-gray-600', 'font-normal');
+            tab.classList.remove(
+              'border-transparent',
+              'text-gray-600',
+              'font-normal',
+              'hover:text-gray-900'
+            );
             tab.classList.add('border-indigo-600', 'text-indigo-600', 'font-semibold');
             tab.setAttribute('aria-selected', 'true');
             renderLists(tab.dataset.client);


### PR DESCRIPTION
## Summary
- remove black hover effect from selected You-are-a tabs
- toggle hover styling when switching between client tabs

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a46004388324a231164198293bb0