### PR TITLE
Fix mobile menu remaining overlay after close

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,23 +376,23 @@
           menuButton.classList.add('text-gray-600');
           overlay.addEventListener(
             'transitionend',
-            function handler(e) {
-              if (e.propertyName === 'opacity') {
+            (e) => {
+              if (e.target === overlay) {
                 overlay.classList.add('hidden');
-                overlay.removeEventListener('transitionend', handler);
               }
-            }
+            },
+            { once: true }
           );
           mobileMenu.addEventListener(
             'transitionend',
-            function handler(e) {
-              if (e.propertyName === 'transform') {
+            (e) => {
+              if (e.target === mobileMenu) {
                 mobileMenu.classList.add('hidden', 'pointer-events-none');
                 mobileMenu.style.top = '';
                 mobileMenu.style.maxHeight = '';
-                mobileMenu.removeEventListener('transitionend', handler);
               }
-            }
+            },
+            { once: true }
           );
         }
 


### PR DESCRIPTION
## Summary
- Ensure mobile navigation menu and overlay hide once transition completes to prevent phantom Contact link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a64405a88324b3372abd94809999