### PR TITLE
Ensure mobile menu slides beneath nav bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,25 +107,25 @@
           >Request Demo</a
         >
       </div>
-      <div
-        id="mobile-menu"
-        class="fixed inset-x-0 z-50 hidden transform rounded-b-lg bg-gray-100 p-6 shadow-lg opacity-0 -translate-y-full pointer-events-none transition duration-300 md:hidden overflow-y-auto"
-      >
-        <nav class="flex flex-col gap-4 text-lg text-left">
-          <a href="#outcomes" class="w-full text-gray-600 hover:text-gray-900">Outcomes</a>
-          <a href="#process" class="w-full text-gray-600 hover:text-gray-900">Process</a>
-          <a href="#customers" class="w-full text-gray-600 hover:text-gray-900">Customers</a>
-          <a href="#about" class="w-full text-gray-600 hover:text-gray-900">About</a>
-          <a href="#contact" class="w-full text-gray-600 hover:text-gray-900">Contact</a>
-          <a
-            href="#contact"
-            class="w-full rounded-md bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500"
-            >Request Demo</a
-          >
-        </nav>
-      </div>
     </header>
-    <div id="menu-overlay" class="fixed inset-0 z-40 hidden bg-black/20 opacity-0 transition-opacity duration-300 md:hidden"></div>
+    <div
+      id="mobile-menu"
+      class="fixed inset-x-0 top-0 z-40 hidden transform rounded-b-lg bg-gray-100 p-6 shadow-lg opacity-0 -translate-y-full pointer-events-none transition duration-300 md:hidden overflow-y-auto"
+    >
+      <nav class="flex flex-col gap-4 text-lg text-left">
+        <a href="#outcomes" class="w-full text-gray-600 hover:text-gray-900">Outcomes</a>
+        <a href="#process" class="w-full text-gray-600 hover:text-gray-900">Process</a>
+        <a href="#customers" class="w-full text-gray-600 hover:text-gray-900">Customers</a>
+        <a href="#about" class="w-full text-gray-600 hover:text-gray-900">About</a>
+        <a href="#contact" class="w-full text-gray-600 hover:text-gray-900">Contact</a>
+        <a
+          href="#contact"
+          class="w-full rounded-md bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500"
+          >Request Demo</a
+        >
+      </nav>
+    </div>
+    <div id="menu-overlay" class="fixed inset-0 z-30 hidden bg-black/20 opacity-0 transition-opacity duration-300 md:hidden"></div>
     <main class="pt-20">
       <section class="bg-white">
         <div class="mx-auto max-w-7xl px-6 py-24 md:grid md:grid-cols-2 md:items-center md:gap-12">


### PR DESCRIPTION
## Summary
- Move mobile menu outside the header and give it a lower z-index so the navigation bar remains above it.
- Adjust menu overlay layering to sit below the menu while dimming page content.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b494f8f8832485dc04a60c40f325