### PR TITLE
Style hero headline with outlined 'Accurate' word

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,14 @@
         transform: translateX(-50%);
         pointer-events: none;
       }
+      .stroke-dotted { stroke-dasharray: 1 5; }
+      .stroke-dash-1 { stroke-dasharray: 2 5; }
+      .stroke-dash-2 { stroke-dasharray: 3 5; }
+      .stroke-dash-3 { stroke-dasharray: 4 5; }
+      .stroke-dash-4 { stroke-dasharray: 5 5; }
+      .stroke-dash-5 { stroke-dasharray: 6 5; }
+      .stroke-dash-6 { stroke-dasharray: 8 5; }
+      .stroke-solid { stroke-dasharray: none; }
     </style>
   </head>
   <body class="bg-gray-50 text-gray-900 antialiased">
@@ -131,7 +139,35 @@
         <div class="mx-auto max-w-7xl px-6 py-24 md:grid md:grid-cols-2 md:items-center md:gap-12">
           <div>
             <p class="text-sm font-semibold uppercase tracking-wide text-indigo-600">Map accuracy &amp; verification</p>
-            <h1 class="mt-4 text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl">Accurate maps that work.</h1>
+            <h1 class="mt-4 text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl">
+              <span class="sr-only">Accurate</span>
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 640 100"
+                class="inline-block h-[1em] w-auto align-baseline text-indigo-600"
+              >
+                <text
+                  x="0"
+                  y="75"
+                  font-family="inherit"
+                  font-size="80"
+                  font-weight="800"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="4"
+                >
+                  <tspan class="stroke-dotted">A</tspan>
+                  <tspan class="stroke-dash-1">c</tspan>
+                  <tspan class="stroke-dash-2">c</tspan>
+                  <tspan class="stroke-dash-3">u</tspan>
+                  <tspan class="stroke-dash-4">r</tspan>
+                  <tspan class="stroke-dash-5">a</tspan>
+                  <tspan class="stroke-dash-6">t</tspan>
+                  <tspan class="stroke-solid">e</tspan>
+                </text>
+              </svg>
+              maps that work.
+            </h1>
             <p class="mt-6 text-lg text-gray-600">
               GeoFidelity checks and corrects OpenStreetMap so your site is findable and accessible across major map platforms.
               Start with a simple audit and fix plan.


### PR DESCRIPTION
## Summary
- Outline "Accurate" in the hero heading using an inline SVG with brand-colored strokes that transition from dotted to solid
- Add stroke pattern utility classes for dotted, dashed, and solid letter outlines

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bd7efb508324a5a11bd4304ac224