### PR TITLE
Restart hero slider animation after inactivity

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,6 +495,11 @@
         function stopBounce() {
           if (bounce) bounce.kill();
         }
+        let restartTimeout;
+        function queueBounceRestart() {
+          clearTimeout(restartTimeout);
+          restartTimeout = setTimeout(startBounce, 5000);
+        }
         setPos(state.p);
         startBounce();
         let dragging = false;
@@ -506,6 +511,7 @@
           } else {
             animateTo(pos);
           }
+          queueBounceRestart();
         }
         slider.addEventListener('pointerenter', (e) => {
           stopBounce();
@@ -527,6 +533,7 @@
         });
         function release() {
           dragging = false;
+          queueBounceRestart();
         }
         slider.addEventListener('pointerup', release);
         slider.addEventListener('pointercancel', release);


### PR DESCRIPTION
## Summary
- Restart hero slider animation five seconds after user stops interacting, continuing from their last slider position

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c03a1f5c8324b133f0bbee3da5b4