### PR TITLE
Refine hero title outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,9 +54,15 @@
       }
       .outline-text {
         color: transparent;
-        -webkit-text-fill-color: transparent;
-        -webkit-text-stroke: 4px #4f46e5;
-        text-stroke: 4px #4f46e5;
+        text-shadow:
+          1px 0 0 #4f46e5,
+         -1px 0 0 #4f46e5,
+          0 1px 0 #4f46e5,
+          0 -1px 0 #4f46e5,
+          1px 1px 0 #4f46e5,
+         -1px -1px 0 #4f46e5,
+          1px -1px 0 #4f46e5,
+         -1px 1px 0 #4f46e5;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- refine outline styling for "Accurate" in hero heading using text-shadow for a thinner, internal stroke

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c6c357208324888a7155651743bf