### PR TITLE
Highlight active nav items on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -590,12 +590,56 @@
           closeMenu();
         });
 
+        let headerHeight;
         function updateScrollPadding() {
-          document.documentElement.style.scrollPaddingTop = `${header.offsetHeight}px`;
+          headerHeight = header.offsetHeight;
+          document.documentElement.style.scrollPaddingTop = `${headerHeight}px`;
         }
         window.addEventListener('load', updateScrollPadding);
-        window.addEventListener('resize', updateScrollPadding);
+        window.addEventListener('resize', () => {
+          updateScrollPadding();
+          onScroll();
+        });
         updateScrollPadding();
+
+        const sectionEls = Array.from(document.querySelectorAll('section[id]'));
+        const linkMap = {};
+        document
+          .querySelectorAll('#desktop-menu a, #mobile-menu a')
+          .forEach((link) => {
+            const id = link.getAttribute('href').slice(1);
+            (linkMap[id] ||= []).push(link);
+          });
+        const activeClasses = ['text-gray-900', 'font-semibold'];
+        const inactiveClasses = ['text-gray-600'];
+        function setActive(id) {
+          Object.values(linkMap).forEach((links) =>
+            links.forEach((l) => {
+              l.classList.remove(...activeClasses);
+              l.classList.add(...inactiveClasses);
+            })
+          );
+          if (id && linkMap[id]) {
+            linkMap[id].forEach((l) => {
+              l.classList.remove(...inactiveClasses);
+              l.classList.add(...activeClasses);
+            });
+          }
+        }
+        function onScroll() {
+          const scrollPos = window.scrollY + headerHeight + 1;
+          let currentId = null;
+          for (const section of sectionEls) {
+            if (scrollPos >= section.offsetTop) {
+              currentId = section.id;
+            } else {
+              break;
+            }
+          }
+          setActive(currentId);
+        }
+        window.addEventListener('scroll', onScroll);
+        window.addEventListener('load', onScroll);
 
       gsap.registerPlugin(ScrollTrigger);
       gsap.utils.toArray('section:not(:first-of-type)').forEach((section) => {


### PR DESCRIPTION
## Summary
- Highlight desktop and mobile nav links when their sections are in view
- Adjust scroll padding dynamically to match header height and scroll state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c686677483249c549192c061a408