### PR TITLE
Make hero slider divider extend beyond images

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,8 @@
       }
       #hero-slider {
         position: relative;
-        overflow: hidden;
+        overflow-x: hidden;
+        overflow-y: visible;
         cursor: ew-resize;
         touch-action: pan-y;
       }
@@ -44,8 +45,8 @@
       }
       #hero-divider {
         position: absolute;
-        top: 0;
-        bottom: 0;
+        top: -1rem;
+        bottom: -1rem;
         width: 4px;
         background: #4f46e5;
         left: 50%;


### PR DESCRIPTION
## Summary
- Allow hero slider divider to stick out above and below images
- Ensure slider container only hides horizontal overflow so the divider remains visible

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c6e981a88324a7fb9342fff2f433