### PR TITLE
Use hero slider images in impact tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,18 +269,12 @@
             <h2 id="impact-heading" class="sr-only">Before and After Map Impact</h2>
             <div class="grid gap-8 md:grid-cols-2">
               <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-                <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
-                  <circle cx="12" cy="10" r="3"/>
-                </svg>
+                <img src="hero-before.svg" alt="Before map" class="w-full rounded" />
                 <h3 class="mt-4 text-xl font-semibold">Before</h3>
                 <p class="mt-2 text-gray-600">Missing paths, mis-pinned entrances, stale POIs. Visitors and deliveries struggle.</p>
               </div>
               <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-                <svg class="h-8 w-8 text-gray-400" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="M21 10c0 6-9 13-9 13s-9-7-9-13a9 9 0 1 1 18 0z"/>
-                  <circle cx="12" cy="10" r="3"/>
-                </svg>
+                <img src="hero-after.svg" alt="After map" class="w-full rounded" />
                 <h3 class="mt-4 text-xl font-semibold">After</h3>
                 <p class="mt-2 text-gray-600">Correct trails, entrances, and amenities. Better routes, fewer mistakes, happier visitors.</p>
               </div>


### PR DESCRIPTION
## Summary
- display the hero before/after SVGs in the Impact section tiles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c72e92c4832484c0056f55300bc5