### PR TITLE
Align section headings with navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
         </section>
         <section id="customers" aria-labelledby="customers-heading" class="bg-white py-24">
           <div class="mx-auto max-w-7xl px-6">
-            <h2 id="customers-heading" class="text-3xl font-bold text-gray-900">You are a...</h2>
+            <h2 id="customers-heading" class="text-center text-3xl font-bold text-gray-900">Customers</h2>
 
             <div class="mt-12">
               <div class="flex border-b border-gray-200 text-sm" role="tablist">
@@ -289,7 +289,7 @@
         </section>
         <section aria-labelledby="services-heading" class="bg-gray-50 py-24">
           <div class="mx-auto max-w-7xl px-6">
-            <h2 id="services-heading" class="text-3xl font-bold text-gray-900">Services</h2>
+            <h2 id="services-heading" class="text-center text-3xl font-bold text-gray-900">Services</h2>
             <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-2">
               <a href="/services" class="block rounded-lg bg-white p-6 shadow transition hover:shadow-md">
                 <h3 class="text-xl font-semibold text-gray-900">Map Readiness Audit</h3>
@@ -306,7 +306,7 @@
         </section>
         <section id="process" aria-labelledby="process-heading" class="bg-white py-24">
           <div class="mx-auto max-w-7xl px-6">
-            <h2 id="process-heading" class="text-3xl font-bold text-gray-900">How it works</h2>
+            <h2 id="process-heading" class="text-center text-3xl font-bold text-gray-900">Process</h2>
             <ol class="mt-12 space-y-8 md:flex md:space-y-0 md:space-x-12">
               <li class="flex items-start gap-4">
                 <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-indigo-600 font-semibold text-white" aria-label="Step 1">1</div>
@@ -332,9 +332,9 @@
             </ol>
           </div>
         </section>
-      <section id="about" class="bg-gray-50 py-24">
+      <section id="about" aria-labelledby="about-heading" class="bg-gray-50 py-24">
         <div class="mx-auto max-w-3xl px-6 text-center">
-          <h2 class="text-3xl font-bold">About GeoFidelity</h2>
+          <h2 id="about-heading" class="text-center text-3xl font-bold text-gray-900">About</h2>
           <p class="mt-6 text-lg text-gray-600">
             We help organisations ensure their site is mapped correctly so visitors, customers and deliveries can find them without hassle.
           </p>
@@ -342,7 +342,7 @@
       </section>
       <section class="bg-indigo-600 py-24 text-white" aria-labelledby="primary-cta-heading">
         <div class="mx-auto max-w-3xl px-6 text-center">
-          <h2 id="primary-cta-heading" class="text-3xl font-bold">Ready to fix your maps?</h2>
+          <h2 id="primary-cta-heading" class="text-center text-3xl font-bold">Ready to fix your maps?</h2>
           <p class="mt-4 text-lg text-indigo-100">Start with a quick Map Readiness Audit and a clear, fixed-price plan.</p>
           <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a href="/contact" class="rounded-md bg-white px-6 py-3 font-medium text-indigo-600 hover:bg-indigo-50">Request an Audit</a>
@@ -350,9 +350,9 @@
           </div>
         </div>
       </section>
-      <section id="contact" class="bg-white py-24">
+      <section id="contact" aria-labelledby="contact-heading" class="bg-white py-24">
         <div class="mx-auto max-w-xl px-6">
-          <h2 class="text-center text-3xl font-bold">Get in Touch</h2>
+          <h2 id="contact-heading" class="text-center text-3xl font-bold text-gray-900">Contact</h2>
           <form
             action="https://api.web3forms.com/submit"
             method="POST"


### PR DESCRIPTION
## Summary
- Match section headings to navigation labels (Customers, Services, Process, About, Contact)
- Standardize section heading styling with consistent Tailwind classes
- Add `aria-labelledby` attributes for About and Contact sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c755b1d483249f0b598ffdeb5c37