### PR TITLE
Reduce hero outline stroke to 1px

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,15 +55,9 @@
       }
       .outline-text {
         color: transparent;
-        text-shadow:
-          1px 0 0 #4f46e5,
-         -1px 0 0 #4f46e5,
-          0 1px 0 #4f46e5,
-          0 -1px 0 #4f46e5,
-          1px 1px 0 #4f46e5,
-         -1px -1px 0 #4f46e5,
-          1px -1px 0 #4f46e5,
-         -1px 1px 0 #4f46e5;
+        -webkit-text-fill-color: transparent;
+        -webkit-text-stroke: 1px #4f46e5;
+        text-stroke: 1px #4f46e5;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- Refine the hero's "Accurate" text outline to a crisp 1px stroke using `-webkit-text-stroke` for a cleaner appearance.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c87bc7a083249e93fd1615aa0151