### PR TITLE
Move impact tiles into outcomes section

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,19 @@
                 </p>
               </div>
             </div>
+            <h3 class="sr-only">Before and After Map Impact</h3>
+            <div class="mt-12 grid gap-8 md:grid-cols-2">
+              <div class="flex flex-col rounded-lg bg-white p-6 shadow">
+                <img src="hero-before.svg" alt="Before map" class="w-full rounded" />
+                <h3 class="mt-4 text-xl font-semibold">Before</h3>
+                <p class="mt-2 text-gray-600">Missing paths, mis-pinned entrances, stale POIs. Visitors and deliveries struggle.</p>
+              </div>
+              <div class="flex flex-col rounded-lg bg-white p-6 shadow">
+                <img src="hero-after.svg" alt="After map" class="w-full rounded" />
+                <h3 class="mt-4 text-xl font-semibold">After</h3>
+                <p class="mt-2 text-gray-600">Correct trails, entrances, and amenities. Better routes, fewer mistakes, happier visitors.</p>
+              </div>
+            </div>
           </div>
         </section>
         <section id="customers" aria-labelledby="customers-heading" class="bg-white py-24">
@@ -267,23 +280,6 @@
                   <h3 class="text-xl font-semibold">After</h3>
                   <ul id="after-list" class="mt-4 space-y-3"></ul>
                 </div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <section aria-labelledby="impact-heading" class="bg-gray-50 py-24">
-          <div class="mx-auto max-w-7xl px-6">
-            <h2 id="impact-heading" class="sr-only">Before and After Map Impact</h2>
-            <div class="grid gap-8 md:grid-cols-2">
-              <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-                <img src="hero-before.svg" alt="Before map" class="w-full rounded" />
-                <h3 class="mt-4 text-xl font-semibold">Before</h3>
-                <p class="mt-2 text-gray-600">Missing paths, mis-pinned entrances, stale POIs. Visitors and deliveries struggle.</p>
-              </div>
-              <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-                <img src="hero-after.svg" alt="After map" class="w-full rounded" />
-                <h3 class="mt-4 text-xl font-semibold">After</h3>
-                <p class="mt-2 text-gray-600">Correct trails, entrances, and amenities. Better routes, fewer mistakes, happier visitors.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Combine before/after impact tiles into Outcomes section and remove redundant Impact section

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b5c9146dc08324bcf8c7420922a0b9