### PR TITLE
Allow hero slider divider overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,7 @@
       }
       #hero-slider {
         position: relative;
-        overflow-x: hidden;
-        overflow-y: visible;
+        overflow: visible;
         cursor: ew-resize;
         touch-action: pan-y;
       }


### PR DESCRIPTION
## Summary
- Allow hero slider to display divider outside image by using `overflow: visible`.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ca57aa60832498c84b4bde79bed2