### PR TITLE
Center close icon in mobile menu button

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
         <button
             id="menu-button"
             type="button"
-            class="relative z-50 rounded-md p-2 text-gray-600 focus:outline-none md:hidden"
+            class="relative z-50 flex items-center justify-center rounded-md p-2 text-gray-600 focus:outline-none md:hidden"
             aria-controls="mobile-menu"
             aria-expanded="false"
           >
@@ -95,7 +95,7 @@
             </svg>
             <svg
               id="icon-close"
-              class="absolute inset-0 h-6 w-6 transform opacity-0 -rotate-90 transition duration-300 pointer-events-none"
+              class="absolute inset-0 m-auto h-6 w-6 transform opacity-0 -rotate-90 transition duration-300 pointer-events-none"
               aria-hidden="true"
               fill="none"
               stroke="currentColor"


### PR DESCRIPTION
## Summary
- ensure mobile menu close `X` icon is centered by applying flex layout to the button and centering the SVG with margin auto

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e62276b08324b11105936357f5d9