### PR TITLE
Align navigation order with page sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,8 +108,8 @@
           </button>
         <nav class="hidden gap-8 text-sm md:flex" id="desktop-menu">
           <a href="#outcomes" class="text-gray-600 hover:text-gray-900">Outcomes</a>
-          <a href="#process" class="text-gray-600 hover:text-gray-900">Process</a>
           <a href="#customers" class="text-gray-600 hover:text-gray-900">Customers</a>
+          <a href="#process" class="text-gray-600 hover:text-gray-900">Process</a>
           <a href="#about" class="text-gray-600 hover:text-gray-900">About</a>
           <a href="#contact" class="text-gray-600 hover:text-gray-900">Contact</a>
         </nav>
@@ -126,8 +126,8 @@
     >
       <nav class="flex flex-col gap-4 text-lg text-left">
         <a href="#outcomes" class="w-full text-gray-600 hover:text-gray-900">Outcomes</a>
-        <a href="#process" class="w-full text-gray-600 hover:text-gray-900">Process</a>
         <a href="#customers" class="w-full text-gray-600 hover:text-gray-900">Customers</a>
+        <a href="#process" class="w-full text-gray-600 hover:text-gray-900">Process</a>
         <a href="#about" class="w-full text-gray-600 hover:text-gray-900">About</a>
         <a href="#contact" class="w-full text-gray-600 hover:text-gray-900">Contact</a>
         <a


### PR DESCRIPTION
## Summary
- Reorder desktop and mobile navigation links so "Customers" appears before "Process", matching page layout

## Testing
- `npx --yes htmlhint index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a8379fa88324b4edc0bcc210188b