### PR TITLE
style: enhance feature list icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,16 +155,16 @@
               <a href="#process" class="px-6 py-3 text-center font-medium text-indigo-600 hover:underline">How it works</a>
             </div>
             <ul class="mt-8 grid gap-3 text-sm text-gray-700 sm:grid-cols-3 sm:gap-6">
-              <li class="flex items-center gap-2 justify-start sm:justify-center">
-                <svg class="h-4 w-4 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+              <li class="flex items-start gap-2 justify-start sm:justify-center">
+                <svg class="h-5 w-5 text-indigo-600 flex-shrink-0" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2 4-4"/></svg>
                 <span>OSM-compliant editing</span>
               </li>
-              <li class="flex items-center gap-2 justify-start sm:justify-center">
-                <svg class="h-4 w-4 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+              <li class="flex items-start gap-2 justify-start sm:justify-center">
+                <svg class="h-5 w-5 text-indigo-600 flex-shrink-0" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2 4-4"/></svg>
                 <span>Open data, properly attributed</span>
               </li>
-              <li class="flex items-center gap-2 justify-start sm:justify-center">
-                <svg class="h-4 w-4 text-indigo-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+              <li class="flex items-start gap-2 justify-start sm:justify-center">
+                <svg class="h-5 w-5 text-indigo-600 flex-shrink-0" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2 4-4"/></svg>
                 <span>Cross-platform visibility</span>
               </li>
             </ul>


### PR DESCRIPTION
## Summary
- swap checkmark icons for bolder check-in-circle design
- top align feature list text next to icons

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/GeoFidelity-site/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b6b082d27083249ebfc4343340d3cc