### PR TITLE
Add alt text for GeoFidelity logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     <header class="fixed inset-x-0 top-0 z-50 bg-white shadow">
       <div class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
         <a href="#" class="flex items-center gap-2">
-          <img src="geofidelity-symbol.svg" alt="" class="h-8 w-auto" />
+          <img src="geofidelity-symbol.svg" alt="GeoFidelity logo" class="h-8 w-auto" />
           <img src="geofidelity-wordmark.svg" alt="GeoFidelity" class="h-8" />
         </a>
         <button


### PR DESCRIPTION
## Summary
- add descriptive alt text to the symbol logo for better accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d53dbf0c8324b3074f91973ae4eb