### PR TITLE
Add skip link to main content

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,9 +64,24 @@
       #contact {
         min-height: calc(100vh - var(--nav-height));
       }
+      .skip-link {
+        position: absolute;
+        top: 0;
+        left: 0;
+        background: #4f46e5;
+        color: white;
+        padding: 0.5rem 1rem;
+        z-index: 100;
+        transform: translateY(-100%);
+        transition: transform 0.2s ease;
+      }
+      .skip-link:focus {
+        transform: translateY(0);
+      }
     </style>
   </head>
   <body class="bg-gray-50 text-gray-900 antialiased">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <header class="fixed inset-x-0 top-0 z-50 bg-white shadow">
       <div class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
         <a href="#" class="flex items-center gap-2">
@@ -138,7 +153,7 @@
       </nav>
     </div>
     <div id="menu-overlay" class="fixed inset-0 z-30 hidden bg-black/20 opacity-0 transition-opacity duration-300 md:hidden"></div>
-    <main class="pt-20">
+    <main id="main-content" class="pt-20">
       <section class="bg-white">
         <div class="mx-auto max-w-7xl px-6 py-24 md:grid md:grid-cols-2 md:items-center md:gap-12">
           <div>


### PR DESCRIPTION
## Summary
- add a hidden "Skip to main content" link that becomes visible on focus
- target the new `main-content` id on the `<main>` element

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d55c93a483249e0755c47632301a