### PR TITLE
Add Services to navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
         <nav class="hidden gap-8 text-sm md:flex" id="desktop-menu">
           <a href="#outcomes" class="text-gray-600 hover:text-gray-900">Outcomes</a>
           <a href="#customers" class="text-gray-600 hover:text-gray-900">Customers</a>
+          <a href="#services" class="text-gray-600 hover:text-gray-900">Services</a>
           <a href="#process" class="text-gray-600 hover:text-gray-900">Process</a>
           <a href="#about" class="text-gray-600 hover:text-gray-900">About</a>
           <a href="#contact" class="text-gray-600 hover:text-gray-900">Contact</a>
@@ -138,6 +139,7 @@
       <nav class="flex flex-col gap-4 text-lg text-left">
         <a href="#outcomes" class="w-full text-gray-600 hover:text-gray-900">Outcomes</a>
         <a href="#customers" class="w-full text-gray-600 hover:text-gray-900">Customers</a>
+        <a href="#services" class="w-full text-gray-600 hover:text-gray-900">Services</a>
         <a href="#process" class="w-full text-gray-600 hover:text-gray-900">Process</a>
         <a href="#about" class="w-full text-gray-600 hover:text-gray-900">About</a>
         <a href="#contact" class="w-full text-gray-600 hover:text-gray-900">Contact</a>
@@ -294,7 +296,7 @@
             </div>
           </div>
         </section>
-        <section aria-labelledby="services-heading" class="bg-gray-50 py-24">
+        <section id="services" aria-labelledby="services-heading" class="bg-gray-50 py-24">
           <div class="mx-auto max-w-7xl px-6">
             <h2 id="services-heading" class="text-center text-3xl font-bold text-gray-900">Services</h2>
             <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-2">


### PR DESCRIPTION
## Summary
- Add Services link to desktop and mobile navigation
- Assign id to Services section for anchor navigation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d6a566188324851a66495af18b51