### PR TITLE
Use PNG maps in hero and before/after sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,9 +198,9 @@
           </div>
           <div class="mt-12 md:mt-0">
             <div id="hero-slider">
-              <img src="hero-before.svg" alt="Before map" />
+              <img src="map-before.png" alt="Before map" />
               <div id="hero-after-wrapper">
-                <img src="hero-after.svg" alt="After map" />
+                <img src="map-after.png" alt="After map" />
               </div>
               <div id="hero-divider"></div>
             </div>
@@ -253,12 +253,12 @@
             <h3 class="sr-only">Before and After Map Impact</h3>
             <div class="mt-12 grid gap-8 md:grid-cols-2">
               <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-                <img src="hero-before.svg" alt="Before map" class="w-full rounded" />
+                <img src="map-before.png" alt="Before map" class="w-full rounded" />
                 <h3 class="mt-4 text-xl font-semibold">Before</h3>
                 <p class="mt-2 text-gray-600">Missing paths, mis-pinned entrances, stale POIs. Visitors and deliveries struggle.</p>
               </div>
               <div class="flex flex-col rounded-lg bg-white p-6 shadow">
-                <img src="hero-after.svg" alt="After map" class="w-full rounded" />
+                <img src="map-after.png" alt="After map" class="w-full rounded" />
                 <h3 class="mt-4 text-xl font-semibold">After</h3>
                 <p class="mt-2 text-gray-600">Correct trails, entrances, and amenities. Better routes, fewer mistakes, happier visitors.</p>
               </div>


### PR DESCRIPTION
## Summary
- replace hero slider map SVGs with new PNG images
- update before/after comparison cards to use PNG maps

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7110084e88324aae13e5eb1e68396