### PR TITLE
style: hide skip link off-screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,17 +71,15 @@
       .skip-link {
         position: absolute;
         top: 0;
-        left: 0;
+        left: -9999px;
         background: #4f46e5;
         color: white;
         padding: 0.5rem 1rem;
         z-index: 100;
-        transform: translateY(-100%);
-        transition: transform 0.2s ease;
       }
       .skip-link:focus {
-        transform: translateY(0);
-
+        left: 0;
+      }
       @media (prefers-reduced-motion: reduce) {
         html {
           scroll-behavior: auto;


### PR DESCRIPTION
## Summary
- keep the skip link available to screen-reader and keyboard users while hiding it off-screen until focus
- close missing CSS block for the skip link

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b759fe20a88324887fcf89e8798cd2