### PR TITLE
Fix sticky customer nav timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1346,8 +1346,18 @@
         const customerNavWrapper = document.getElementById("customer-nav-wrapper");
         const servicesSection = document.getElementById("services");
         const navPlaceholder = document.createElement("div");
-        navPlaceholder.style.height = customerNavWrapper.offsetHeight + "px";
-        const navOffsetTop = customerNavWrapper.offsetTop;
+        let navOffsetTop;
+
+        function updateCustomerNavMetrics() {
+          navPlaceholder.style.height =
+            customerNavWrapper.offsetHeight + "px";
+          navOffsetTop = customerNavWrapper.offsetTop;
+        }
+
+        updateCustomerNavMetrics();
+        window.addEventListener("load", updateCustomerNavMetrics);
+        window.addEventListener("resize", updateCustomerNavMetrics);
+
         window.addEventListener("scroll", () => {
           const servicesBottom =
             servicesSection.offsetTop + servicesSection.offsetHeight;
@@ -1382,6 +1392,7 @@
             );
             if (navPlaceholder.parentNode)
               navPlaceholder.parentNode.removeChild(navPlaceholder);
+            updateCustomerNavMetrics();
           }
         });
 


### PR DESCRIPTION
## Summary
- Recalculate customer navigation bar offset after load and resize
- Refresh placeholder and offset when releasing sticky state

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ee89a06c832485de6dbd887f440a