### PR TITLE
Fix sticky customer nav layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,9 +424,11 @@
       </section>
       <section id="customer-sections">
         <div id="customer-nav-container" class="mt-24">
-          <p class="mb-4 text-center text-lg italic text-gray-700">
-            We are a...
-          </p>
+          <div class="mx-auto max-w-7xl px-6">
+            <p class="mb-4 text-center text-lg font-semibold text-gray-700">
+              We are a...
+            </p>
+          </div>
           <div
             id="customer-nav-wrapper"
             class="sticky top-[var(--nav-height)] z-30 w-full bg-white"
@@ -461,7 +463,6 @@
             </button>
           </div>
           </div>
-        </div>
 
         <section
           id="use-cases"
@@ -506,6 +507,7 @@
             ></div>
           </div>
         </section>
+        </div>
       </section>
       <section
         id="process"


### PR DESCRIPTION
## Summary
- Bold "We are" heading placed above customer nav within section container
- Ensure sticky customer nav remains active across use-case and services sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fb807898832487f646bcedd17503