### PR TITLE
Refine process timeline layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,14 +208,15 @@
             >
               Map accuracy &amp; verification
             </p>
-              <h1
-                class="mt-4 text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl"
-              >
-                Help every visitor reach your site effortlessly.
-              </h1>
-              <p class="mt-6 text-lg text-gray-600">
-                GeoFidelity identifies and corrects OpenStreetMap data so customers, drivers, and deliveries can reach you without detours.
-              </p>
+            <h1
+              class="mt-4 text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl"
+            >
+              Help every visitor reach your site effortlessly.
+            </h1>
+            <p class="mt-6 text-lg text-gray-600">
+              GeoFidelity identifies and corrects OpenStreetMap data so
+              customers, drivers, and deliveries can reach you without detours.
+            </p>
             <div class="mt-8 flex flex-col gap-4 sm:flex-row">
               <a
                 href="/contact"
@@ -435,76 +436,76 @@
               class="mx-auto max-w-7xl px-6 flex border-b border-gray-200 text-sm"
               role="tablist"
             >
-            <button
-              class="client-tab border-b-2 border-indigo-600 px-4 py-2 text-indigo-600 font-semibold"
-              data-client="housing"
-              role="tab"
-              aria-selected="true"
-            >
-              Housing Developer
-            </button>
-            <button
-              class="client-tab border-b-2 border-transparent px-4 py-2 text-gray-600 hover:text-gray-900 font-normal"
-              data-client="tourism"
-              role="tab"
-              aria-selected="false"
-            >
-              Tourism Board
-            </button>
-            <button
-              class="client-tab border-b-2 border-transparent px-4 py-2 text-gray-600 hover:text-gray-900 font-normal"
-              data-client="park"
-              role="tab"
-              aria-selected="false"
-            >
-              National Park Authority
-            </button>
-          </div>
-          </div>
-
-        <section
-          id="use-cases"
-          aria-labelledby="use-cases-heading"
-          class="bg-white pt-12 pb-24"
-        >
-          <div class="mx-auto max-w-7xl px-6">
-            <h2
-              id="use-cases-heading"
-              class="text-center text-3xl font-bold text-gray-900"
-            >
-              Use Cases
-            </h2>
-
-            <div class="mt-12 grid gap-8 md:grid-cols-2">
-              <div>
-                <h3 class="text-xl font-semibold">Before</h3>
-                <ul id="before-list" class="mt-4 space-y-3"></ul>
-              </div>
-              <div>
-                <h3 class="text-xl font-semibold">After</h3>
-                <ul id="after-list" class="mt-4 space-y-3"></ul>
-              </div>
+              <button
+                class="client-tab border-b-2 border-indigo-600 px-4 py-2 text-indigo-600 font-semibold"
+                data-client="housing"
+                role="tab"
+                aria-selected="true"
+              >
+                Housing Developer
+              </button>
+              <button
+                class="client-tab border-b-2 border-transparent px-4 py-2 text-gray-600 hover:text-gray-900 font-normal"
+                data-client="tourism"
+                role="tab"
+                aria-selected="false"
+              >
+                Tourism Board
+              </button>
+              <button
+                class="client-tab border-b-2 border-transparent px-4 py-2 text-gray-600 hover:text-gray-900 font-normal"
+                data-client="park"
+                role="tab"
+                aria-selected="false"
+              >
+                National Park Authority
+              </button>
             </div>
           </div>
-        </section>
-        <section
-          id="services"
-          aria-labelledby="services-heading"
-          class="bg-gray-50 py-24"
-        >
-          <div class="mx-auto max-w-7xl px-6">
-            <h2
-              id="services-heading"
-              class="text-center text-3xl font-bold text-gray-900"
-            >
-              Services
-            </h2>
-            <div
-              id="tier-container"
-              class="mt-12 flex space-x-6 overflow-x-auto snap-x snap-mandatory lg:grid lg:grid-cols-3 lg:gap-8 lg:space-x-0"
-            ></div>
-          </div>
-        </section>
+
+          <section
+            id="use-cases"
+            aria-labelledby="use-cases-heading"
+            class="bg-white pt-12 pb-24"
+          >
+            <div class="mx-auto max-w-7xl px-6">
+              <h2
+                id="use-cases-heading"
+                class="text-center text-3xl font-bold text-gray-900"
+              >
+                Use Cases
+              </h2>
+
+              <div class="mt-12 grid gap-8 md:grid-cols-2">
+                <div>
+                  <h3 class="text-xl font-semibold">Before</h3>
+                  <ul id="before-list" class="mt-4 space-y-3"></ul>
+                </div>
+                <div>
+                  <h3 class="text-xl font-semibold">After</h3>
+                  <ul id="after-list" class="mt-4 space-y-3"></ul>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section
+            id="services"
+            aria-labelledby="services-heading"
+            class="bg-gray-50 py-24"
+          >
+            <div class="mx-auto max-w-7xl px-6">
+              <h2
+                id="services-heading"
+                class="text-center text-3xl font-bold text-gray-900"
+              >
+                Services
+              </h2>
+              <div
+                id="tier-container"
+                class="mt-12 flex space-x-6 overflow-x-auto snap-x snap-mandatory lg:grid lg:grid-cols-3 lg:gap-8 lg:space-x-0"
+              ></div>
+            </div>
+          </section>
         </div>
       </section>
       <section
@@ -520,76 +521,99 @@
             Process
           </h2>
           <div class="relative mt-20">
-            <div class="absolute left-4 top-0 h-full w-px bg-gray-200 md:left-1/2"></div>
-            <ol class="space-y-32">
-              <li class="relative grid min-h-[80vh] grid-cols-[2rem_1fr] md:grid-cols-[1fr_2rem_1fr]">
-                <div class="col-start-2 sticky top-20 self-start md:col-start-1 md:pr-8 md:text-right relative">
-                  <div class="rounded-lg border border-indigo-600 bg-white p-6 shadow">
-                    <h3 class="text-xl font-semibold">Identify mapping gaps</h3>
-                    <p class="mt-2 text-gray-600">
-                      Discover where major maps misdirect visitors.
-                    </p>
+            <div
+              class="absolute left-4 top-0 h-full w-px bg-gray-200 lg:left-1/2"
+            ></div>
+            <ol class="space-y-16">
+              <li class="relative min-h-[40vh]">
+                <div
+                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                >
+                  <div class="flex justify-center lg:col-start-2">
+                    <span
+                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                    ></span>
                   </div>
-                  <div class="absolute top-1/2 right-[-1rem] hidden h-px w-4 bg-indigo-600 md:block"></div>
-                </div>
-                <div class="col-start-1 flex justify-center md:col-start-2 sticky top-20 self-start">
-                  <span class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"></span>
-                </div>
-              </li>
-              <li class="relative grid min-h-[80vh] grid-cols-[2rem_1fr] md:grid-cols-[1fr_2rem_1fr]">
-                <div class="col-start-2 sticky top-20 self-start md:col-start-3 md:pl-8 relative">
-                  <div class="rounded-lg border border-indigo-600 bg-white p-6 shadow">
-                    <h3 class="text-xl font-semibold">Improve map accuracy</h3>
-                    <p class="mt-2 text-gray-600">
-                      Update OpenStreetMap so directions lead customers straight to you.
-                    </p>
-                    <ul class="mt-4 list-disc pl-5 text-gray-600 md:hidden">
-                      <li>Public data</li>
-                      <li>Commercial data</li>
-                    </ul>
-                  </div>
-                  <div class="absolute top-1/2 left-[-1rem] hidden h-px w-4 bg-indigo-600 md:block"></div>
-                </div>
-                <div class="col-start-1 flex justify-center md:col-start-2 sticky top-20 self-start">
-                  <div class="relative flex flex-col items-center">
-                    <span class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"></span>
-                    <div class="absolute left-1/2 top-1/2 hidden -translate-x-1/2 md:block">
-                      <div class="absolute -left-32 top-0 h-px w-32 bg-gray-200"></div>
-                      <div class="absolute -left-32 top-0 -translate-y-1/2 h-3 w-3 rounded-full bg-indigo-400"></div>
-                      <div class="absolute -left-32 top-4 -translate-y-1/2 text-sm text-gray-600">Public data</div>
-                      <div class="absolute left-0 top-0 h-px w-32 bg-gray-200"></div>
-                      <div class="absolute left-32 top-0 -translate-y-1/2 h-3 w-3 rounded-full bg-indigo-400"></div>
-                      <div class="absolute left-32 top-4 -translate-y-1/2 text-sm text-gray-600">Commercial data</div>
+                  <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
+                    <div class="rounded-lg bg-white p-6">
+                      <h3 class="text-xl font-semibold">
+                        Identify mapping gaps
+                      </h3>
+                      <p class="mt-2 text-gray-600">
+                        Discover where major maps misdirect visitors.
+                      </p>
                     </div>
                   </div>
                 </div>
               </li>
-              <li class="relative grid min-h-[80vh] grid-cols-[2rem_1fr] md:grid-cols-[1fr_2rem_1fr]">
-                <div class="col-start-2 sticky top-20 self-start md:col-start-1 md:pr-8 md:text-right relative">
-                  <div class="rounded-lg border border-indigo-600 bg-white p-6 shadow">
-                    <h3 class="text-xl font-semibold">Publish updates everywhere</h3>
-                    <p class="mt-2 text-gray-600">
-                      Share corrections so Apple and Google show the right location.
-                    </p>
+              <li class="relative min-h-[40vh]">
+                <div
+                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                >
+                  <div class="flex justify-center lg:col-start-2">
+                    <span
+                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                    ></span>
                   </div>
-                  <div class="absolute top-1/2 right-[-1rem] hidden h-px w-4 bg-indigo-600 md:block"></div>
-                </div>
-                <div class="col-start-1 flex justify-center md:col-start-2 sticky top-20 self-start">
-                  <span class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"></span>
+                  <div class="col-start-2 lg:col-start-3 lg:pl-8">
+                    <div class="rounded-lg bg-white p-6">
+                      <h3 class="text-xl font-semibold">
+                        Improve map accuracy
+                      </h3>
+                      <p class="mt-2 text-gray-600">
+                        Update OpenStreetMap so directions lead customers
+                        straight to you.
+                      </p>
+                      <ul class="mt-4 list-disc pl-5 text-gray-600">
+                        <li>Public data</li>
+                        <li>Commercial data</li>
+                      </ul>
+                    </div>
+                  </div>
                 </div>
               </li>
-              <li class="relative grid min-h-[80vh] grid-cols-[2rem_1fr] md:grid-cols-[1fr_2rem_1fr]">
-                <div class="col-start-2 sticky top-20 self-start md:col-start-3 md:pl-8 relative">
-                  <div class="rounded-lg border border-indigo-600 bg-white p-6 shadow">
-                    <h3 class="text-xl font-semibold">Confirm customers can find you</h3>
-                    <p class="mt-2 text-gray-600">
-                      Check updated maps to ensure visitors and deliveries reach the right spot.
-                    </p>
+              <li class="relative min-h-[40vh]">
+                <div
+                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                >
+                  <div class="flex justify-center lg:col-start-2">
+                    <span
+                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                    ></span>
                   </div>
-                  <div class="absolute top-1/2 left-[-1rem] hidden h-px w-4 bg-indigo-600 md:block"></div>
+                  <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
+                    <div class="rounded-lg bg-white p-6">
+                      <h3 class="text-xl font-semibold">
+                        Publish updates everywhere
+                      </h3>
+                      <p class="mt-2 text-gray-600">
+                        Share corrections so Apple and Google show the right
+                        location.
+                      </p>
+                    </div>
+                  </div>
                 </div>
-                <div class="col-start-1 flex justify-center md:col-start-2 sticky top-20 self-start">
-                  <span class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"></span>
+              </li>
+              <li class="relative min-h-[40vh]">
+                <div
+                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                >
+                  <div class="flex justify-center lg:col-start-2">
+                    <span
+                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                    ></span>
+                  </div>
+                  <div class="col-start-2 lg:col-start-3 lg:pl-8">
+                    <div class="rounded-lg bg-white p-6">
+                      <h3 class="text-xl font-semibold">
+                        Confirm customers can find you
+                      </h3>
+                      <p class="mt-2 text-gray-600">
+                        Check updated maps to ensure visitors and deliveries
+                        reach the right spot.
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </li>
             </ol>
@@ -619,12 +643,13 @@
         aria-labelledby="primary-cta-heading"
       >
         <div class="mx-auto max-w-3xl px-6 text-center">
-            <h2 id="primary-cta-heading" class="text-center text-3xl font-bold">
-              Ready to help customers find you?
-            </h2>
-            <p class="mt-4 text-lg text-indigo-100">
-              Get a Map Readiness Audit and a tailored plan so visitors never get lost.
-            </p>
+          <h2 id="primary-cta-heading" class="text-center text-3xl font-bold">
+            Ready to help customers find you?
+          </h2>
+          <p class="mt-4 text-lg text-indigo-100">
+            Get a Map Readiness Audit and a tailored plan so visitors never get
+            lost.
+          </p>
           <div
             class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row"
           >
@@ -705,7 +730,9 @@
                       <option>Government</option>
                       <option value="other">Other</option>
                     </select>
-                    <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                    <div
+                      class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3"
+                    >
                       <svg
                         class="h-5 w-5 text-gray-400"
                         fill="none"
@@ -714,7 +741,11 @@
                         viewBox="0 0 24 24"
                         aria-hidden="true"
                       >
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M19 9l-7 7-7-7"
+                        />
                       </svg>
                     </div>
                   </div>
@@ -811,7 +842,9 @@
                         <option value="km²">km²</option>
                         <option value="mi²">mi²</option>
                       </select>
-                      <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                      <div
+                        class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2"
+                      >
                         <svg
                           class="h-5 w-5 text-gray-400"
                           fill="none"
@@ -820,7 +853,11 @@
                           viewBox="0 0 24 24"
                           aria-hidden="true"
                         >
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            d="M19 9l-7 7-7-7"
+                          />
                         </svg>
                       </div>
                     </div>
@@ -1235,64 +1272,61 @@
         },
       };
 
-        const serviceTiers = [
-          {
-            title: "Open Source Compilation",
-            what: "We identify, clean, and compile the best available open data sources (OpenStreetMap, Wikidata, local authority releases, etc.), then upload updates on your behalf.",
-            who: {
-              housing:
-                "Housing Developer: Add new estate roads, footpaths, and amenities so buyers see their homes appear in digital maps from day one.",
-              tourism:
-                "Tourism Board: Standardise points of interest (heritage sites, attractions, hospitality) so visitors find you consistently in every mapping app.",
-              park:
-                "National Park Authority: Ensure trails, car parks, visitor centres, and waymarked routes are visible and accurate across Google, Apple, and OSM-derived apps.",
-            },
-            deliverables: [
-              "Aggregated and cleaned dataset",
-              "Verified OSM updates and third-party submissions",
-              "Annual audit of key coverage",
-            ],
+      const serviceTiers = [
+        {
+          title: "Open Source Compilation",
+          what: "We identify, clean, and compile the best available open data sources (OpenStreetMap, Wikidata, local authority releases, etc.), then upload updates on your behalf.",
+          who: {
+            housing:
+              "Housing Developer: Add new estate roads, footpaths, and amenities so buyers see their homes appear in digital maps from day one.",
+            tourism:
+              "Tourism Board: Standardise points of interest (heritage sites, attractions, hospitality) so visitors find you consistently in every mapping app.",
+            park: "National Park Authority: Ensure trails, car parks, visitor centres, and waymarked routes are visible and accurate across Google, Apple, and OSM-derived apps.",
           },
-          {
-            title: "Expert Validation & Enrichment",
-            what: "Our specialists cross-check data against authoritative sources, enrich it with metadata (accessibility, opening hours, facilities), and liaise with platform maintainers to accelerate adoption.",
-            who: {
-              housing:
-                "Housing Developer: Highlight amenities (playgrounds, bus stops, green spaces) and ensure address ranges are properly indexed.",
-              tourism:
-                "Tourism Board: Add booking links, photos, and tags to improve discoverability in travel platforms.",
-              park:
-                "National Park Authority: Ensure accessibility data (wheelchair routes, gradients, toilets) is consistently visible across major apps.",
-            },
-            deliverables: [
-              "Fully validated dataset with rich metadata",
-              "Quarterly updates and corrections",
-              "Direct engagement with third-party platforms (Apple, Google, Mapbox, etc.)",
-            ],
+          deliverables: [
+            "Aggregated and cleaned dataset",
+            "Verified OSM updates and third-party submissions",
+            "Annual audit of key coverage",
+          ],
+        },
+        {
+          title: "Expert Validation & Enrichment",
+          what: "Our specialists cross-check data against authoritative sources, enrich it with metadata (accessibility, opening hours, facilities), and liaise with platform maintainers to accelerate adoption.",
+          who: {
+            housing:
+              "Housing Developer: Highlight amenities (playgrounds, bus stops, green spaces) and ensure address ranges are properly indexed.",
+            tourism:
+              "Tourism Board: Add booking links, photos, and tags to improve discoverability in travel platforms.",
+            park: "National Park Authority: Ensure accessibility data (wheelchair routes, gradients, toilets) is consistently visible across major apps.",
           },
-          {
-            title: "First-Party Capture & Ground Truth",
-            what: "We deploy field teams or equip your staff with mobile survey tools to capture first-party data—GPS-verified routes, accessibility audits, signage inventories, and high-accuracy photos.",
-            who: {
-              housing:
-                "Housing Developer: On-site mapping of new developments, capturing address ranges, site access, and construction phasing to keep maps current as homes are handed over.",
-              tourism:
-                "Tourism Board: Capture verified imagery, footfall counts, and street-level navigation details to stand out on digital platforms.",
-              park:
-                "National Park Authority: Survey trails, signage, and safety infrastructure to ensure accuracy in both maps and emergency-services databases.",
-            },
-            deliverables: [
-              "Verified first-party dataset with GPS traces and images",
-              "Monthly/real-time updates through our platform",
-              "Priority integrations with partner mapping services",
-            ],
+          deliverables: [
+            "Fully validated dataset with rich metadata",
+            "Quarterly updates and corrections",
+            "Direct engagement with third-party platforms (Apple, Google, Mapbox, etc.)",
+          ],
+        },
+        {
+          title: "First-Party Capture & Ground Truth",
+          what: "We deploy field teams or equip your staff with mobile survey tools to capture first-party data—GPS-verified routes, accessibility audits, signage inventories, and high-accuracy photos.",
+          who: {
+            housing:
+              "Housing Developer: On-site mapping of new developments, capturing address ranges, site access, and construction phasing to keep maps current as homes are handed over.",
+            tourism:
+              "Tourism Board: Capture verified imagery, footfall counts, and street-level navigation details to stand out on digital platforms.",
+            park: "National Park Authority: Survey trails, signage, and safety infrastructure to ensure accuracy in both maps and emergency-services databases.",
           },
-        ];
+          deliverables: [
+            "Verified first-party dataset with GPS traces and images",
+            "Monthly/real-time updates through our platform",
+            "Priority integrations with partner mapping services",
+          ],
+        },
+      ];
 
-        const beforeList = document.getElementById("before-list");
-        const afterList = document.getElementById("after-list");
-        const tabs = document.querySelectorAll(".client-tab");
-        const tierContainer = document.getElementById("tier-container");
+      const beforeList = document.getElementById("before-list");
+      const afterList = document.getElementById("after-list");
+      const tabs = document.querySelectorAll(".client-tab");
+      const tierContainer = document.getElementById("tier-container");
 
       const icons = {
         positive:
@@ -1301,7 +1335,7 @@
           '<svg class="h-5 w-5 text-red-600" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M6 18L18 6"/></svg>',
       };
 
-        function renderLists(type) {
+      function renderLists(type) {
         const data = scenarios[type];
         const oldItems = [...beforeList.children, ...afterList.children];
         const populate = () => {
@@ -1338,18 +1372,18 @@
         } else {
           populate();
         }
-        }
+      }
 
-        function renderServices(type) {
-          const oldCards = [...tierContainer.children];
+      function renderServices(type) {
+        const oldCards = [...tierContainer.children];
 
-          const populate = () => {
-            tierContainer.innerHTML = "";
-            serviceTiers.forEach((tier) => {
-              const card = document.createElement("div");
-              card.className =
-                "snap-start w-[80%] flex-none rounded-lg bg-white p-6 shadow lg:w-auto";
-              card.innerHTML = `
+        const populate = () => {
+          tierContainer.innerHTML = "";
+          serviceTiers.forEach((tier) => {
+            const card = document.createElement("div");
+            card.className =
+              "snap-start w-[80%] flex-none rounded-lg bg-white p-6 shadow lg:w-auto";
+            card.innerHTML = `
                 <h3 class="text-xl font-semibold text-gray-900">${tier.title}</h3>
                 <p class="mt-2 text-gray-600">${tier.what}</p>
                 <div class="mt-4">
@@ -1365,33 +1399,33 @@
                   </ul>
                 </div>
               `;
-              tierContainer.appendChild(card);
-            });
-            const newCards = [...tierContainer.children];
-            if (motionOK) {
-              gsap.fromTo(
-                newCards,
-                { opacity: 0, y: 10 },
-                { opacity: 1, y: 0, duration: 0.2, stagger: 0.05 },
-              );
-            }
-          };
-
-          if (oldCards.length && motionOK) {
-            gsap.to(oldCards, {
-              opacity: 0,
-              y: 10,
-              duration: 0.2,
-              onComplete: populate,
-            });
-          } else {
-            populate();
+            tierContainer.appendChild(card);
+          });
+          const newCards = [...tierContainer.children];
+          if (motionOK) {
+            gsap.fromTo(
+              newCards,
+              { opacity: 0, y: 10 },
+              { opacity: 1, y: 0, duration: 0.2, stagger: 0.05 },
+            );
           }
-        }
+        };
 
-        tabs.forEach((tab) => {
-          tab.addEventListener("click", () => {
-            if (tab.getAttribute("aria-selected") === "true") return;
+        if (oldCards.length && motionOK) {
+          gsap.to(oldCards, {
+            opacity: 0,
+            y: 10,
+            duration: 0.2,
+            onComplete: populate,
+          });
+        } else {
+          populate();
+        }
+      }
+
+      tabs.forEach((tab) => {
+        tab.addEventListener("click", () => {
+          if (tab.getAttribute("aria-selected") === "true") return;
           tabs.forEach((t) => {
             t.classList.remove(
               "border-indigo-600",
@@ -1419,13 +1453,13 @@
             "font-semibold",
           );
           tab.setAttribute("aria-selected", "true");
-            renderLists(tab.dataset.client);
-            renderServices(tab.dataset.client);
-          });
+          renderLists(tab.dataset.client);
+          renderServices(tab.dataset.client);
         });
+      });
 
-        renderLists("housing");
-        renderServices("housing");
+      renderLists("housing");
+      renderServices("housing");
 
       const contactForm = document.getElementById("contact-form");
       const contactSlides = document.querySelectorAll(".contact-slide");


### PR DESCRIPTION
## Summary
- Remove process step card outlines and connector lines
- Wrap nodes and text in shared sticky grids and reduce spacing for tighter flow
- Shift to desktop layout at `lg` breakpoint and show data sources within cards

## Testing
- `npx prettier --write index.html`
- `npx prettier --check index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b84ceaee448324a0ab8e63923506c3