### PR TITLE
style: apply brand colors to process timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,11 +478,11 @@
 
               <div class="mt-12 grid gap-8 md:grid-cols-2">
                 <div>
-                  <h3 class="text-xl font-semibold">Before</h3>
+                  <h3 class="text-xl font-semibold text-indigo-600">Before</h3>
                   <ul id="before-list" class="mt-4 space-y-3"></ul>
                 </div>
                 <div>
-                  <h3 class="text-xl font-semibold">After</h3>
+                  <h3 class="text-xl font-semibold text-indigo-600">After</h3>
                   <ul id="after-list" class="mt-4 space-y-3"></ul>
                 </div>
               </div>
@@ -524,21 +524,21 @@
           </h2>
           <div class="relative mt-20">
             <div
-              class="absolute left-4 top-0 h-full w-px bg-gray-200 lg:left-1/2"
+              class="absolute left-4 top-0 h-full w-px bg-indigo-600 lg:left-1/2"
             ></div>
             <ol class="space-y-16">
               <li class="relative min-h-[40vh]">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex justify-center lg:col-start-2">
                     <span
-                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                      class="block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
                     <div class="rounded-lg bg-white p-6">
-                      <h3 class="text-xl font-semibold">
+                      <h3 class="text-xl font-semibold text-indigo-600">
                         Identify mapping gaps
                       </h3>
                       <p class="mt-2 text-gray-600">
@@ -550,16 +550,16 @@
               </li>
               <li class="relative min-h-[40vh]">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex justify-center lg:col-start-2">
                     <span
-                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                      class="block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-3 lg:pl-8">
                     <div class="rounded-lg bg-white p-6">
-                      <h3 class="text-xl font-semibold">
+                      <h3 class="text-xl font-semibold text-indigo-600">
                         Improve map accuracy
                       </h3>
                       <p class="mt-2 text-gray-600">
@@ -576,16 +576,16 @@
               </li>
               <li class="relative min-h-[40vh]">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex justify-center lg:col-start-2">
                     <span
-                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                      class="block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
                     <div class="rounded-lg bg-white p-6">
-                      <h3 class="text-xl font-semibold">
+                      <h3 class="text-xl font-semibold text-indigo-600">
                         Publish updates everywhere
                       </h3>
                       <p class="mt-2 text-gray-600">
@@ -598,16 +598,16 @@
               </li>
               <li class="relative min-h-[40vh]">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex justify-center lg:col-start-2">
                     <span
-                      class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
+                      class="block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-3 lg:pl-8">
                     <div class="rounded-lg bg-white p-6">
-                      <h3 class="text-xl font-semibold">
+                      <h3 class="text-xl font-semibold text-indigo-600">
                         Confirm customers can find you
                       </h3>
                       <p class="mt-2 text-gray-600">


### PR DESCRIPTION
## Summary
- Tint process timeline line and step headings with brand color
- Align step headings with their timeline nodes

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9575d3a948324b0329c5bade81b6e