### PR TITLE
Align process titles with timeline nodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,7 +537,7 @@
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
-                    <div class="rounded-lg bg-white p-6">
+                    <div class="rounded-lg bg-white px-6 py-4">
                       <h3 class="text-xl font-semibold text-indigo-600">
                         Identify mapping gaps
                       </h3>
@@ -558,7 +558,7 @@
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-3 lg:pl-8">
-                    <div class="rounded-lg bg-white p-6">
+                    <div class="rounded-lg bg-white px-6 py-4">
                       <h3 class="text-xl font-semibold text-indigo-600">
                         Improve map accuracy
                       </h3>
@@ -584,7 +584,7 @@
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
-                    <div class="rounded-lg bg-white p-6">
+                    <div class="rounded-lg bg-white px-6 py-4">
                       <h3 class="text-xl font-semibold text-indigo-600">
                         Publish updates everywhere
                       </h3>
@@ -606,7 +606,7 @@
                     ></span>
                   </div>
                   <div class="col-start-2 lg:col-start-3 lg:pl-8">
-                    <div class="rounded-lg bg-white p-6">
+                    <div class="rounded-lg bg-white px-6 py-4">
                       <h3 class="text-xl font-semibold text-indigo-600">
                         Confirm customers can find you
                       </h3>


### PR DESCRIPTION
## Summary
- Adjust process timeline card padding so each step's title aligns with its timeline node.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ba0659c83248cbe360747ccb93f