### PR TITLE
fix: improve iOS navbar and menu handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta
       name="description"
       content="Ensure customers and deliveries find you with accurate map data across platforms."
@@ -14,6 +17,8 @@
     <style>
       :root {
         --nav-height: 0px;
+        --safe-top: env(safe-area-inset-top);
+        --safe-bottom: env(safe-area-inset-bottom);
       }
       html {
         scroll-behavior: smooth;
@@ -23,9 +28,15 @@
         outline: 2px solid #4f46e5;
         outline-offset: 2px;
       }
+      body.menu-open header,
       body.menu-open main,
       body.menu-open footer {
         filter: blur(4px);
+      }
+      html.menu-open,
+      body.menu-open {
+        height: 100dvh;
+        overflow: hidden;
       }
       main,
       footer {
@@ -67,6 +78,8 @@
       }
       #contact {
         min-height: calc(100vh - var(--nav-height));
+        min-height: calc(100svh - var(--nav-height));
+        min-height: calc(100dvh - var(--nav-height));
       }
       .skip-link {
         position: absolute;
@@ -93,7 +106,10 @@
   </head>
   <body class="bg-gray-50 text-gray-900 antialiased">
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    <header class="fixed inset-x-0 top-0 z-50 bg-white shadow">
+    <header
+      style="padding-top: var(--safe-top)"
+      class="sticky top-0 z-50 bg-white shadow"
+    >
       <div
         class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4"
       >
@@ -165,8 +181,9 @@
     </header>
     <div
       id="mobile-menu"
+      style="padding-bottom: calc(1.5rem + var(--safe-bottom))"
       class="fixed inset-x-0 top-0 z-40 hidden transform rounded-b-lg bg-gray-100 p-6 shadow-lg opacity-0 -translate-y-full pointer-events-none transition duration-300 md:hidden overflow-y-auto"
-    >
+      >
       <nav class="flex flex-col gap-4 text-lg text-left">
         <a href="#outcomes" class="w-full text-gray-600 hover:text-gray-900"
           >Outcomes</a
@@ -197,7 +214,7 @@
       id="menu-overlay"
       class="fixed inset-0 z-30 hidden bg-black/20 opacity-0 transition-opacity duration-300 md:hidden"
     ></div>
-    <main id="main-content" class="pt-20">
+    <main id="main-content">
       <section class="bg-white">
         <div
           class="mx-auto max-w-7xl px-6 py-24 md:grid md:grid-cols-2 md:items-center md:gap-12"
@@ -1089,8 +1106,9 @@
 
       function openMenu() {
         const topOffset = header.offsetHeight;
+        const vh = CSS.supports("height: 100dvh") ? "dvh" : "vh";
         mobileMenu.style.top = `${topOffset}px`;
-        mobileMenu.style.maxHeight = `calc(100vh - ${topOffset}px)`;
+        mobileMenu.style.maxHeight = `calc(100${vh} - ${topOffset}px)`;
         mobileMenu.classList.remove("hidden", "pointer-events-none");
         overlay.classList.remove("hidden");
         requestAnimationFrame(() => {
@@ -1098,7 +1116,8 @@
           mobileMenu.classList.remove("-translate-y-full", "opacity-0");
           overlay.classList.add("opacity-100");
         });
-        document.body.classList.add("overflow-hidden", "menu-open");
+        document.documentElement.classList.add("menu-open");
+        document.body.classList.add("menu-open");
         openIcon.classList.add("opacity-0", "rotate-90");
         closeIcon.classList.remove("opacity-0", "-rotate-90");
         menuButton.classList.add("bg-indigo-600", "text-white", "rounded-full");
@@ -1110,7 +1129,8 @@
         mobileMenu.classList.remove("translate-y-0", "opacity-100");
         overlay.classList.remove("opacity-100");
         overlay.classList.add("opacity-0");
-        document.body.classList.remove("overflow-hidden", "menu-open");
+        document.documentElement.classList.remove("menu-open");
+        document.body.classList.remove("menu-open");
         openIcon.classList.remove("opacity-0", "rotate-90");
         closeIcon.classList.add("opacity-0", "-rotate-90");
         menuButton.classList.remove(


### PR DESCRIPTION
## Summary
- ensure safe-area compliance and sticky header
- lock scroll and blur nav when menu opens
- use dynamic viewport units for mobile menu and contact section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3d9bd5888324b350989d5d29eb1a