### PR TITLE
Fix nav bar displaying behind blur when menu open

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
         outline: 2px solid #4f46e5;
         outline-offset: 2px;
       }
-      body.menu-open header,
       body.menu-open main,
       body.menu-open footer {
         filter: blur(4px);


### PR DESCRIPTION
## Summary
- remove header from elements blurred when menu opens so navigation bar remains visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3fead7348324873418e9b68fef43