### PR TITLE
Expand process timeline styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,44 +571,33 @@
             ></div>
             <ol class="space-y-16">
               <li class="relative min-h-[40vh]">
-                <div
-                  class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
-                >
-                  <div class="flex justify-center lg:col-start-2">
-                    <span
-                      class="block h-4 w-4 rounded-full bg-indigo-600"
-                    ></span>
+                <div class="sticky top-20 grid grid-cols-[2rem_1fr] items-start lg:grid-cols-[1fr_2rem_1fr]">
+                  <div class="flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+                    <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                   </div>
                   <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
-                    <div class="rounded-lg bg-white px-6 py-4">
+                    <div class="rounded-lg bg-white px-6 py-4" style="box-shadow:0 2px 4px rgba(0,0,0,0.1);">
                       <h3 class="text-xl font-semibold text-indigo-600">
+                        <span class="block text-sm font-bold uppercase text-gray-500" style="letter-spacing:0.1em;">Step 1</span>
                         Identify mapping gaps
                       </h3>
-                      <p class="mt-2 text-gray-600">
-                        Discover where major maps misdirect visitors.
-                      </p>
+                      <p class="mt-2 text-gray-600">Discover where major maps misdirect visitors.</p>
                     </div>
                   </div>
                 </div>
               </li>
               <li class="relative min-h-[40vh]">
-                <div
-                  class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
-                >
-                  <div class="flex justify-center lg:col-start-2">
-                    <span
-                      class="block h-4 w-4 rounded-full bg-indigo-600"
-                    ></span>
+                <div class="sticky top-20 grid grid-cols-[2rem_1fr] items-start lg:grid-cols-[1fr_2rem_1fr]">
+                  <div class="flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+                    <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                   </div>
                   <div class="col-start-2 lg:col-start-3 lg:pl-8">
-                    <div class="rounded-lg bg-white px-6 py-4">
+                    <div class="rounded-lg bg-white px-6 py-4" style="box-shadow:0 2px 4px rgba(0,0,0,0.1);">
                       <h3 class="text-xl font-semibold text-indigo-600">
+                        <span class="block text-sm font-bold uppercase text-gray-500" style="letter-spacing:0.1em;">Step 2</span>
                         Improve map accuracy
                       </h3>
-                      <p class="mt-2 text-gray-600">
-                        Update OpenStreetMap so directions lead customers
-                        straight to you.
-                      </p>
+                      <p class="mt-2 text-gray-600">Update OpenStreetMap so directions lead customers straight to you.</p>
                       <ul class="mt-4 list-disc pl-5 text-gray-600">
                         <li>Public data</li>
                         <li>Commercial data</li>
@@ -618,100 +607,68 @@
                 </div>
               </li>
               <li class="relative min-h-[40vh]">
-                <div
-                  class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
-                >
-                  <div class="flex justify-center lg:col-start-2">
-                    <span
-                      class="block h-4 w-4 rounded-full bg-indigo-600"
-                    ></span>
+                <div class="sticky top-20 grid grid-cols-[2rem_1fr] items-start lg:grid-cols-[1fr_2rem_1fr]">
+                  <div class="flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+                    <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                   </div>
                   <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
-                    <div class="rounded-lg bg-white px-6 py-4">
+                    <div class="rounded-lg bg-white px-6 py-4" style="box-shadow:0 2px 4px rgba(0,0,0,0.1);">
                       <h3 class="text-xl font-semibold text-indigo-600">
+                        <span class="block text-sm font-bold uppercase text-gray-500" style="letter-spacing:0.1em;">Step 3</span>
                         Publish updates everywhere
                       </h3>
-                      <p class="mt-2 text-gray-600">
-                        Share corrections so Apple and Google show the right
-                        location.
-                      </p>
+                      <p class="mt-2 text-gray-600">Share corrections so Apple and Google show the right location.</p>
                     </div>
                   </div>
                 </div>
               </li>
-                <li class="relative min-h-[40vh]">
-                  <div
-                    class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
-                  >
-                    <div class="flex justify-center lg:col-start-2">
-                      <span
-                        class="block h-4 w-4 rounded-full bg-indigo-600"
-                      ></span>
-                    </div>
-                    <div class="col-start-2 lg:col-start-3 lg:pl-8">
-                      <div class="rounded-lg bg-white p-6">
-                        <h3 class="text-xl font-semibold text-indigo-600">
-                          Confirm customers can find you
-                        </h3>
-                        <p class="mt-2 text-gray-600">
-                          Check updated maps to ensure visitors and deliveries
-                          reach the right spot.
-                        </p>
-                      </div>
-                    </div>
+              <li class="relative min-h-[40vh]">
+                <div class="sticky top-20 grid grid-cols-[2rem_1fr] items-start lg:grid-cols-[1fr_2rem_1fr]">
+                  <div class="flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+                    <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                   </div>
-                </li>
-                <li class="relative min-h-[40vh]">
-                  <div
-                    class="sticky top-20 grid items-start grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
-                  >
-                    <div class="flex justify-center lg:col-start-2">
-                      <span
-                        class="block h-4 w-4 rounded-full bg-indigo-600"
-                      ></span>
-                    </div>
-                    <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
-                      <div class="rounded-lg bg-white p-6">
-                        <h3 class="text-xl font-semibold text-indigo-600">
-                          Improved data reaches end users
-                        </h3>
-                        <p class="mt-2 text-gray-600">
-                          Accurate maps power every platform.
-                        </p>
-                        <div class="mt-4 flex flex-col items-start gap-2 lg:items-end">
-                          <div class="flex items-center gap-2">
-                            <div class="h-px w-8 bg-indigo-600"></div>
-                            <span class="text-gray-600"
-                              >Consumer apps (Apple, Google)</span
-                            >
-                          </div>
-                          <div class="flex items-center gap-2">
-                            <div class="h-px w-8 bg-indigo-600"></div>
-                            <span class="text-gray-600"
-                              >Aggregators (Mapbox, etc.)</span
-                            >
-                          </div>
-                          <div class="flex items-center gap-2">
-                            <div class="h-px w-8 bg-indigo-600"></div>
-                            <span class="text-gray-600"
-                              >1st party uses (customer websites/tooling)</span
-                            >
-                          </div>
-                        </div>
-                      </div>
                   <div class="col-start-2 lg:col-start-3 lg:pl-8">
-                    <div class="rounded-lg bg-white px-6 py-4">
+                    <div class="rounded-lg bg-white px-6 py-4" style="box-shadow:0 2px 4px rgba(0,0,0,0.1);">
                       <h3 class="text-xl font-semibold text-indigo-600">
+                        <span class="block text-sm font-bold uppercase text-gray-500" style="letter-spacing:0.1em;">Step 4</span>
                         Confirm customers can find you
                       </h3>
-                      <p class="mt-2 text-gray-600">
-                        Check updated maps to ensure visitors and deliveries
-                        reach the right spot.
-                      </p>
+                      <p class="mt-2 text-gray-600">Check updated maps to ensure visitors and deliveries reach the right spot.</p>
                     </div>
                   </div>
-                </li>
-              </ol>
+                </div>
+              </li>
+              <li class="relative min-h-[40vh]">
+                <div class="sticky top-20 grid grid-cols-[2rem_1fr] items-start lg:grid-cols-[1fr_2rem_1fr]">
+                  <div class="flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+                    <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
+                  </div>
+                  <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
+                    <div class="rounded-lg bg-white px-6 py-4" style="box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+                      <h3 class="text-xl font-semibold text-indigo-600">
+                        <span class="block text-sm font-bold uppercase text-gray-500" style="letter-spacing:0.1em;">Step 5</span>
+                        Improved data reaches end users
+                      </h3>
+                      <p class="mt-2 text-gray-600">Accurate maps power every platform.</p>
+                      <div class="mt-4 flex flex-col items-start gap-2 lg:items-end">
+                        <div class="flex items-center gap-2">
+                          <div class="h-px w-8 bg-indigo-600"></div>
+                          <span class="text-gray-600">Consumer apps (Apple, Google)</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                          <div class="h-px w-8 bg-indigo-600"></div>
+                          <span class="text-gray-600">Aggregators (Mapbox, etc.)</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                          <div class="h-px w-8 bg-indigo-600"></div>
+                          <span class="text-gray-600">1st party uses (customer websites/tooling)</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ol>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- Add numbered steps and card styling to the process timeline
- Align timeline nodes with the center of step headings using calculated margins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a676d06c83248bf9de574397a083