### PR TITLE
Fix mobile branching timeline alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,21 +654,21 @@
                     </div>
                     <div class="col-start-2 mt-8 lg:col-start-3 lg:pl-8">
                       <div class="flex flex-col gap-4 md:flex-row md:gap-8">
-                        <div class="flex items-center md:flex-1 lg:-ml-8">
+                        <div class="flex items-center -ml-6 md:ml-0 md:flex-1 lg:-ml-8">
                           <div class="h-px flex-grow bg-indigo-600"></div>
                           <span class="mr-2 block h-4 w-4 flex-shrink-0 rounded-full bg-indigo-600"></span>
                           <div class="flex-1 rounded-lg bg-white px-4 py-2 shadow text-gray-600">
                             Consumer apps (Apple, Google)
                           </div>
                         </div>
-                        <div class="flex items-center md:flex-1 lg:-ml-8">
+                        <div class="flex items-center -ml-6 md:ml-0 md:flex-1 lg:-ml-8">
                           <div class="h-px flex-grow bg-indigo-600"></div>
                           <span class="mr-2 block h-4 w-4 flex-shrink-0 rounded-full bg-indigo-600"></span>
                           <div class="flex-1 rounded-lg bg-white px-4 py-2 shadow text-gray-600">
                             Aggregators (Mapbox, etc.)
                           </div>
                         </div>
-                        <div class="flex items-center md:flex-1 lg:-ml-8">
+                        <div class="flex items-center -ml-6 md:ml-0 md:flex-1 lg:-ml-8">
                           <div class="h-px flex-grow bg-indigo-600"></div>
                           <span class="mr-2 block h-4 w-4 flex-shrink-0 rounded-full bg-indigo-600"></span>
                           <div class="flex-1 rounded-lg bg-white px-4 py-2 shadow text-gray-600">


### PR DESCRIPTION
## Summary
- adjust default left offset for branching timeline entries so mobile connectors align without overshooting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b29372348324b3bfdc8efbb192de