### PR TITLE
Fix timeline line and step alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,11 +571,11 @@
           >
             <div
               id="process-line"
-              class="sticky top-20 col-start-1 row-start-1 row-end-2 h-full w-px justify-self-center bg-indigo-600 lg:col-start-2"
+              class="pointer-events-none absolute inset-y-0 left-[1rem] w-px bg-indigo-600 lg:left-1/2 lg:-translate-x-1/2"
             ></div>
-            <ol class="col-span-full space-y-16">
-              <li class="relative grid min-h-[40vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
-                <div class="sticky top-20 flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+            <ol class="col-span-full">
+              <li class="relative grid min-h-[50vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
+                <div class="sticky top-20 flex justify-center lg:col-start-2">
                   <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                 </div>
                 <div class="sticky top-20 col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
@@ -586,8 +586,8 @@
                   <p class="mt-2 text-gray-600">Discover where major maps misdirect visitors.</p>
                 </div>
               </li>
-              <li class="relative grid min-h-[40vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
-                <div class="sticky top-20 flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+              <li class="relative grid min-h-[50vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
+                <div class="sticky top-20 flex justify-center lg:col-start-2">
                   <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                 </div>
                 <div class="sticky top-20 col-start-2 lg:col-start-3 lg:pl-8">
@@ -602,8 +602,8 @@
                   </ul>
                 </div>
               </li>
-              <li class="relative grid min-h-[40vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
-                <div class="sticky top-20 flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+              <li class="relative grid min-h-[50vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
+                <div class="sticky top-20 flex justify-center lg:col-start-2">
                   <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                 </div>
                 <div class="sticky top-20 col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
@@ -614,8 +614,8 @@
                   <p class="mt-2 text-gray-600">Share corrections so Apple and Google show the right location.</p>
                 </div>
               </li>
-              <li class="relative grid min-h-[40vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
-                <div class="sticky top-20 flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+              <li class="relative grid min-h-[50vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
+                <div class="sticky top-20 flex justify-center lg:col-start-2">
                   <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                 </div>
                 <div class="sticky top-20 col-start-2 lg:col-start-3 lg:pl-8">
@@ -626,8 +626,8 @@
                   <p class="mt-2 text-gray-600">Check updated maps to ensure visitors and deliveries reach the right spot.</p>
                 </div>
               </li>
-              <li class="relative grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
-                <div class="sticky top-20 flex justify-center lg:col-start-2" style="margin-top: calc(1rem + 0.625rem);">
+              <li class="relative grid min-h-[50vh] grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]">
+                <div class="sticky top-20 flex justify-center lg:col-start-2">
                   <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
                 </div>
                 <div class="sticky top-20 col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">


### PR DESCRIPTION
## Summary
- Position process timeline line absolutely so it spans the container and centers on desktop
- Align sticky step content with its marker and use 50vh height for consistent spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ccb5933483249640c91d7ef444d2