### PR TITLE
Thicken timeline and branch lines for consistent alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@
           >
             <div
               id="process-line"
-              class="pointer-events-none absolute inset-y-0 left-[1rem] w-px bg-indigo-600 lg:left-1/2 lg:-translate-x-1/2"
+              class="pointer-events-none absolute inset-y-0 left-[calc(1rem_-_0.0625rem)] w-[0.125rem] bg-indigo-600 lg:left-1/2 lg:-translate-x-1/2"
             ></div>
             <ol class="col-span-full">
               <li class="relative min-h-screen">
@@ -708,11 +708,11 @@
             class="relative mt-0 grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8"
           >
             <div
-              class="absolute top-0 left-0 right-0 h-px bg-indigo-600 md:left-[calc(16.666%_-_0.667rem_-_0.5px)] md:right-[calc(16.666%_-_0.667rem_-_0.5px)]"
+              class="absolute top-0 left-0 right-0 h-[0.125rem] bg-indigo-600 md:left-[calc(16.666%_-_0.667rem_-_0.0625rem)] md:right-[calc(16.666%_-_0.667rem_-_0.0625rem)]"
             ></div>
 
             <div class="flex flex-col items-center">
-              <div class="h-6 w-px -mt-px bg-indigo-600"></div>
+              <div class="h-6 w-[0.125rem] -mt-[0.125rem] bg-indigo-600"></div>
               <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
               <div
                 class="mt-2 rounded-lg bg-white px-4 py-2 text-center shadow text-gray-600"
@@ -722,7 +722,7 @@
             </div>
 
             <div class="flex flex-col items-center">
-              <div class="h-6 w-px -mt-px bg-indigo-600"></div>
+              <div class="h-6 w-[0.125rem] -mt-[0.125rem] bg-indigo-600"></div>
               <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
               <div
                 class="mt-2 rounded-lg bg-white px-4 py-2 text-center shadow text-gray-600"
@@ -732,7 +732,7 @@
             </div>
 
             <div class="flex flex-col items-center">
-              <div class="h-6 w-px -mt-px bg-indigo-600"></div>
+              <div class="h-6 w-[0.125rem] -mt-[0.125rem] bg-indigo-600"></div>
               <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
               <div
                 class="mt-2 rounded-lg bg-white px-4 py-2 text-center shadow text-gray-600"


### PR DESCRIPTION
## Summary
- increase process timeline line to 0.125rem and adjust positioning for accurate centering
- widen branch diagram lines to 0.125rem with corrected offsets

## Testing
- `npx prettier --check index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c4101095888324b3002d94167b02a9