### PR TITLE
fix: align branch lines with thicker timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,11 +708,11 @@
             class="relative mt-0 grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8"
           >
             <div
-              class="absolute top-0 left-0 right-0 h-[0.125rem] bg-indigo-600 md:left-[calc(16.666%_-_0.667rem_-_0.0625rem)] md:right-[calc(16.666%_-_0.667rem_-_0.0625rem)]"
+              class="absolute top-0 left-0 right-0 h-[0.125rem] bg-indigo-600 md:left-[calc(16.666%_-_0.667rem_-_0.125rem)] md:right-[calc(16.666%_-_0.667rem_-_0.125rem)]"
             ></div>
 
             <div class="flex flex-col items-center">
-              <div class="h-6 w-[0.125rem] -mt-[0.125rem] bg-indigo-600"></div>
+              <div class="h-6 w-[0.125rem] mt-[0.125rem] bg-indigo-600"></div>
               <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
               <div
                 class="mt-2 rounded-lg bg-white px-4 py-2 text-center shadow text-gray-600"
@@ -722,7 +722,7 @@
             </div>
 
             <div class="flex flex-col items-center">
-              <div class="h-6 w-[0.125rem] -mt-[0.125rem] bg-indigo-600"></div>
+              <div class="h-6 w-[0.125rem] mt-[0.125rem] bg-indigo-600"></div>
               <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
               <div
                 class="mt-2 rounded-lg bg-white px-4 py-2 text-center shadow text-gray-600"
@@ -732,7 +732,7 @@
             </div>
 
             <div class="flex flex-col items-center">
-              <div class="h-6 w-[0.125rem] -mt-[0.125rem] bg-indigo-600"></div>
+              <div class="h-6 w-[0.125rem] mt-[0.125rem] bg-indigo-600"></div>
               <span class="block h-4 w-4 rounded-full bg-indigo-600"></span>
               <div
                 class="mt-2 rounded-lg bg-white px-4 py-2 text-center shadow text-gray-600"


### PR DESCRIPTION
## Summary
- adjust branch timeline offsets for 0.125rem line width
- move branch connectors below horizontal line for proper alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c41dc20bac83249490faf1f746bad5