### PR TITLE
Shorten branch timeline line ends

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,7 +708,7 @@
             class="relative mt-0 grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-8"
           >
             <div
-              class="absolute top-0 left-0 right-0 h-[0.125rem] bg-indigo-600 md:left-[calc(16.666%_-_0.667rem_-_0.125rem)] md:right-[calc(16.666%_-_0.667rem_-_0.125rem)]"
+              class="absolute top-0 left-[0.0625rem] right-[0.0625rem] h-[0.125rem] bg-indigo-600 md:left-[calc(16.666%_-_0.667rem_-_0.0625rem)] md:right-[calc(16.666%_-_0.667rem_-_0.0625rem)]"
             ></div>
 
             <div class="flex flex-col items-center">


### PR DESCRIPTION
## Summary
- shorten the branch timeline horizontal bar by half its thickness on each end for cleaner alignment

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c42419ec048324814a2ec348894b48