### PR TITLE
Add automatic theme system with footer toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme-preference="auto">
   <head>
     <meta charset="UTF-8" />
     <meta
@@ -11,6 +11,36 @@
       content="Ensure customers and deliveries find you with accurate map data across platforms."
     />
     <title>GeoFidelity</title>
+    <script>
+      (function () {
+        const storageKey = "geofidelity-theme";
+        const docEl = document.documentElement;
+        let storedPreference = null;
+        try {
+          storedPreference = localStorage.getItem(storageKey);
+        } catch (error) {
+          storedPreference = null;
+        }
+        const allowed = new Set(["light", "dark", "auto"]);
+        const preference =
+          storedPreference && allowed.has(storedPreference)
+            ? storedPreference
+            : docEl.getAttribute("data-theme-preference") || "auto";
+        docEl.setAttribute("data-theme-preference", preference);
+        const systemPrefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)",
+        ).matches;
+        const resolved =
+          preference === "dark"
+            ? "dark"
+            : preference === "light"
+              ? "light"
+              : systemPrefersDark
+                ? "dark"
+                : "light";
+        docEl.setAttribute("data-theme", resolved);
+      })();
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js"></script>
@@ -19,13 +49,138 @@
         --nav-height: 0px;
         --safe-top: env(safe-area-inset-top);
         --safe-bottom: env(safe-area-inset-bottom);
+        --transition-duration: 0.3s;
+        --color-brand: #4f46e5;
+        --color-text-inverse: #ffffff;
+        color-scheme: light;
+        --color-background: #f8fafc;
+        --color-background-muted: #eef2ff;
+        --color-surface: #ffffff;
+        --color-surface-alt: #f5f7ff;
+        --color-surface-muted: #e0e7ff;
+        --color-surface-contrast: #312e81;
+        --color-overlay: rgba(15, 23, 42, 0.25);
+        --color-border: #d6dcff;
+        --color-border-strong: #b9c2ff;
+        --color-text-primary: #0f172a;
+        --color-text-secondary: #1f2937;
+        --color-text-muted: #4b5563;
+        --color-text-subtle: #6b7280;
+        --color-text-tertiary: #94a3b8;
+        --color-accent: #4f46e5;
+        --color-accent-hover: #4338ca;
+        --color-accent-soft: #eef2ff;
+        --color-accent-soft-hover: #e0e7ff;
+        --color-accent-soft-foreground: #312e81;
+        --color-focus-ring: #818cf8;
+        --color-control: #e0e7ff;
+        --color-control-hover: #d2dbff;
+        --color-success: #16a34a;
+        --color-danger: #dc2626;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
+          --color-background: #0b0630;
+          --color-background-muted: #120d40;
+          --color-surface: #16113f;
+          --color-surface-alt: #1d184c;
+          --color-surface-muted: #28245f;
+          --color-surface-contrast: #060322;
+          --color-overlay: rgba(6, 5, 26, 0.65);
+          --color-border: #302c66;
+          --color-border-strong: #3e3a7b;
+          --color-text-primary: #f6f5ff;
+          --color-text-secondary: #d8d6ff;
+          --color-text-muted: #b6b3f5;
+          --color-text-subtle: #9a96df;
+          --color-text-tertiary: #7d78c3;
+          --color-accent: #8188ff;
+          --color-accent-hover: #a3a8ff;
+          --color-accent-soft: #1c1745;
+          --color-accent-soft-hover: #25205a;
+          --color-accent-soft-foreground: #d8d6ff;
+          --color-focus-ring: #b0b5ff;
+          --color-control: #2a2660;
+          --color-control-hover: #343070;
+          --color-success: #4ade80;
+          --color-danger: #fca5a5;
+        }
+      }
+      [data-theme="light"] {
+        color-scheme: light;
+        --color-background: #f8fafc;
+        --color-background-muted: #eef2ff;
+        --color-surface: #ffffff;
+        --color-surface-alt: #f5f7ff;
+        --color-surface-muted: #e0e7ff;
+        --color-surface-contrast: #312e81;
+        --color-overlay: rgba(15, 23, 42, 0.25);
+        --color-border: #d6dcff;
+        --color-border-strong: #b9c2ff;
+        --color-text-primary: #0f172a;
+        --color-text-secondary: #1f2937;
+        --color-text-muted: #4b5563;
+        --color-text-subtle: #6b7280;
+        --color-text-tertiary: #94a3b8;
+        --color-accent: #4f46e5;
+        --color-accent-hover: #4338ca;
+        --color-accent-soft: #eef2ff;
+        --color-accent-soft-hover: #e0e7ff;
+        --color-accent-soft-foreground: #312e81;
+        --color-focus-ring: #818cf8;
+        --color-control: #e0e7ff;
+        --color-control-hover: #d2dbff;
+        --color-success: #16a34a;
+        --color-danger: #dc2626;
+      }
+      [data-theme="dark"] {
+        color-scheme: dark;
+        --color-background: #0b0630;
+        --color-background-muted: #120d40;
+        --color-surface: #16113f;
+        --color-surface-alt: #1d184c;
+        --color-surface-muted: #28245f;
+        --color-surface-contrast: #060322;
+        --color-overlay: rgba(6, 5, 26, 0.65);
+        --color-border: #302c66;
+        --color-border-strong: #3e3a7b;
+        --color-text-primary: #f6f5ff;
+        --color-text-secondary: #d8d6ff;
+        --color-text-muted: #b6b3f5;
+        --color-text-subtle: #9a96df;
+        --color-text-tertiary: #7d78c3;
+        --color-accent: #8188ff;
+        --color-accent-hover: #a3a8ff;
+        --color-accent-soft: #1c1745;
+        --color-accent-soft-hover: #25205a;
+        --color-accent-soft-foreground: #d8d6ff;
+        --color-focus-ring: #b0b5ff;
+        --color-control: #2a2660;
+        --color-control-hover: #343070;
+        --color-success: #4ade80;
+        --color-danger: #fca5a5;
       }
       html {
         scroll-behavior: smooth;
+        background-color: var(--color-background);
+      }
+      body {
+        background-color: var(--color-background);
+        color: var(--color-text-primary);
+        transition: background-color var(--transition-duration) ease,
+          color var(--transition-duration) ease;
+      }
+      a {
+        color: var(--color-accent);
+        transition: color var(--transition-duration) ease;
+      }
+      a:hover {
+        color: var(--color-accent-hover);
       }
       a:focus-visible,
       button:focus-visible {
-        outline: 2px solid #4f46e5;
+        outline: 2px solid var(--color-focus-ring);
         outline-offset: 2px;
       }
       body.menu-open main,
@@ -37,9 +192,24 @@
         height: 100dvh;
         overflow: hidden;
       }
+      header,
       main,
-      footer {
-        transition: filter 0.3s ease;
+      footer,
+      section,
+      .bg-white,
+      .bg-gray-50,
+      .bg-gray-100,
+      .bg-gray-200,
+      .bg-gray-900,
+      .bg-indigo-50,
+      .bg-indigo-600,
+      .theme-toggle,
+      .theme-toggle button,
+      .creator-credit::after {
+        transition: background-color var(--transition-duration) ease,
+          color var(--transition-duration) ease,
+          border-color var(--transition-duration) ease,
+          filter 0.3s ease;
       }
       #hero-slider {
         position: relative;
@@ -64,7 +234,7 @@
         top: -1rem;
         bottom: -1rem;
         width: 4px;
-        background: #4f46e5;
+        background: var(--color-accent);
         left: 50%;
         transform: translateX(-50%);
         pointer-events: none;
@@ -72,8 +242,8 @@
       .outline-text {
         color: transparent;
         -webkit-text-fill-color: transparent;
-        -webkit-text-stroke: 1px #4f46e5;
-        text-stroke: 1px #4f46e5;
+        -webkit-text-stroke: 1px var(--color-accent);
+        text-stroke: 1px var(--color-accent);
       }
       #contact {
         min-height: calc(100vh - var(--nav-height));
@@ -84,21 +254,198 @@
         position: absolute;
         top: 0;
         left: -9999px;
-        background: #4f46e5;
-        color: white;
+        background: var(--color-accent);
+        color: var(--color-text-inverse);
         padding: 0.5rem 1rem;
         z-index: 100;
       }
       .skip-link:focus {
         left: 0;
       }
+      .bg-white {
+        background-color: var(--color-surface) !important;
+      }
+      .bg-gray-50 {
+        background-color: var(--color-background-muted) !important;
+      }
+      .bg-gray-100 {
+        background-color: var(--color-surface-alt) !important;
+      }
+      .bg-gray-200 {
+        background-color: var(--color-control) !important;
+      }
+      .bg-gray-900 {
+        background-color: var(--color-surface-contrast) !important;
+      }
+      .bg-indigo-600 {
+        background-color: var(--color-accent) !important;
+      }
+      .hover\:bg-indigo-500:hover {
+        background-color: var(--color-accent-hover) !important;
+      }
+      .bg-indigo-50 {
+        background-color: var(--color-accent-soft) !important;
+      }
+      .hover\:bg-indigo-50:hover {
+        background-color: var(--color-accent-soft-hover) !important;
+      }
+      .bg-black\/20 {
+        background-color: var(--color-overlay) !important;
+      }
+      .text-white {
+        color: var(--color-text-inverse) !important;
+      }
+      .text-gray-900 {
+        color: var(--color-text-primary) !important;
+      }
+      .text-gray-700 {
+        color: var(--color-text-secondary) !important;
+      }
+      .text-gray-600 {
+        color: var(--color-text-muted) !important;
+      }
+      .text-gray-500 {
+        color: var(--color-text-subtle) !important;
+      }
+      .text-gray-400 {
+        color: var(--color-text-tertiary) !important;
+      }
+      .text-indigo-600 {
+        color: var(--color-accent) !important;
+      }
+      .text-indigo-100 {
+        color: var(--color-accent-soft-foreground) !important;
+      }
+      .hover\:text-gray-900:hover,
+      .hover\:text-gray-900:focus-visible {
+        color: var(--color-text-primary) !important;
+      }
+      .text-green-600 {
+        color: var(--color-success) !important;
+      }
+      .text-red-600 {
+        color: var(--color-danger) !important;
+      }
+      .border-gray-200 {
+        border-color: var(--color-border) !important;
+      }
+      .border-gray-300 {
+        border-color: var(--color-border-strong) !important;
+      }
+      .border-indigo-600 {
+        border-color: var(--color-accent) !important;
+      }
+      .border-indigo-500 {
+        border-color: var(--color-accent-hover) !important;
+      }
+      .focus\:border-indigo-500:focus {
+        border-color: var(--color-accent) !important;
+      }
+      .focus\:ring-indigo-500:focus {
+        --tw-ring-color: var(--color-accent) !important;
+      }
+      .theme-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem;
+        border-radius: 9999px;
+        border: 1px solid var(--color-border);
+        background-color: var(--color-surface-alt);
+        transition: background-color var(--transition-duration) ease,
+          border-color var(--transition-duration) ease,
+          box-shadow var(--transition-duration) ease;
+      }
+      .theme-toggle button {
+        border: none;
+        background: transparent;
+        color: var(--color-text-muted);
+        font-weight: 500;
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+        padding: 0.35rem 0.9rem;
+        border-radius: 9999px;
+        cursor: pointer;
+        transition: color var(--transition-duration) ease,
+          background-color var(--transition-duration) ease,
+          box-shadow var(--transition-duration) ease;
+      }
+      .theme-toggle button.is-active {
+        background-color: var(--color-surface);
+        color: var(--color-text-primary);
+        box-shadow: 0 0 0 1px var(--color-border-strong);
+      }
+      .theme-toggle button:is(:hover, :focus-visible) {
+        color: var(--color-text-primary);
+      }
+      .creator-credit {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.35rem 0.85rem;
+        border-radius: 9999px;
+        font-weight: 500;
+        font-size: 0.75rem;
+        line-height: 1;
+        color: var(--color-text-inverse);
+        isolation: isolate;
+        overflow: hidden;
+      }
+      .creator-credit::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: linear-gradient(
+          90deg,
+          var(--color-accent),
+          #60a5fa,
+          var(--color-accent)
+        );
+        background-size: 200% 200%;
+        animation: gradientShift 8s ease infinite;
+        opacity: 0.9;
+        z-index: -2;
+      }
+      .creator-credit::after {
+        content: "";
+        position: absolute;
+        inset: 1px;
+        border-radius: inherit;
+        background-color: var(--color-background-muted);
+        opacity: 0.85;
+        z-index: -1;
+        transition: background-color var(--transition-duration) ease,
+          opacity var(--transition-duration) ease;
+      }
+      .creator-credit:hover::after,
+      .creator-credit:focus-visible::after {
+        opacity: 1;
+      }
+      .creator-credit span {
+        position: relative;
+      }
       @media (prefers-reduced-motion: reduce) {
         html {
           scroll-behavior: auto;
         }
+        body,
+        header,
         main,
-        footer {
-          transition: none;
+        footer,
+        section,
+        .bg-white,
+        .bg-gray-50,
+        .bg-gray-100,
+        .bg-gray-200,
+        .bg-gray-900,
+        .bg-indigo-50,
+        .bg-indigo-600,
+        .theme-toggle,
+        .theme-toggle button,
+        .creator-credit::after {
+          transition: none !important;
         }
       }
       @keyframes gradientShift {
@@ -114,7 +461,7 @@
       }
     </style>
   </head>
-  <body class="bg-gray-50 text-gray-900 antialiased">
+  <body class="antialiased">
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <header
       style="padding-top: var(--safe-top)"
@@ -1038,56 +1385,42 @@
     </main>
     <footer class="bg-gray-900 py-12 text-sm text-gray-400">
       <div
-        class="mx-auto max-w-7xl px-6 text-center flex flex-col items-center gap-4 md:flex-row md:justify-between md:text-left"
+        class="mx-auto flex max-w-7xl flex-col items-center gap-6 px-6 text-center md:flex-row md:items-center md:justify-between md:text-left"
       >
         <p>&copy; <span id="year"></span> GeoFidelity. All rights reserved.</p>
-        <a
-          href="https://www.liamday.co.uk"
-          target="_blank"
-          rel="noopener"
-          style="
-            position: relative;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            padding: 0.25rem 0.75rem;
-            border-radius: 9999px;
-            font-weight: 500;
-            font-size: 0.75rem;
-            line-height: 1;
-            background-color: #000;
-            color: transparent;
-          "
-        >
-          <span
-            style="
-              position: absolute;
-              inset: 0;
-              border-radius: inherit;
-              padding: 1px;
-              background: linear-gradient(90deg, #8b5cf6, #3b82f6, #8b5cf6);
-              background-size: 200% 200%;
-              animation: gradientShift 8s ease infinite;
-              -webkit-mask:
-                linear-gradient(#000 0 0) content-box,
-                linear-gradient(#000 0 0);
-              -webkit-mask-composite: xor;
-              mask-composite: exclude;
-              pointer-events: none;
-            "
-          ></span>
-          <span
-            style="
-              background: linear-gradient(90deg, #8b5cf6, #3b82f6, #8b5cf6);
-              background-size: 200% 200%;
-              animation: gradientShift 8s ease infinite;
-              -webkit-background-clip: text;
-              background-clip: text;
-              color: transparent;
-            "
-            >Built by www.liamday.co.uk</span
+        <div class="flex flex-col items-center gap-4 md:flex-row md:items-center md:gap-6">
+          <div class="flex flex-col items-center gap-2 sm:flex-row sm:items-center sm:gap-3">
+            <span
+              id="appearance-label"
+              class="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500"
+              >Appearance</span
+            >
+            <div
+              class="theme-toggle"
+              role="group"
+              aria-labelledby="appearance-label"
+              data-theme-toggle
+            >
+              <button type="button" data-theme-value="light" aria-pressed="false">
+                Light
+              </button>
+              <button type="button" data-theme-value="auto" aria-pressed="false">
+                Auto
+              </button>
+              <button type="button" data-theme-value="dark" aria-pressed="false">
+                Dark
+              </button>
+            </div>
+          </div>
+          <a
+            href="https://www.liamday.co.uk"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="creator-credit"
           >
-        </a>
+            <span>Built by www.liamday.co.uk</span>
+          </a>
+        </div>
       </div>
     </footer>
     <script>
@@ -1208,6 +1541,76 @@
       const menuLinks = mobileMenu.querySelectorAll("a");
       const overlay = document.getElementById("menu-overlay");
       const header = document.querySelector("header");
+
+      const themeToggle = document.querySelector("[data-theme-toggle]");
+      const themeButtons = themeToggle
+        ? Array.from(
+            themeToggle.querySelectorAll("button[data-theme-value]"),
+          )
+        : [];
+      const themeStorageKey = "geofidelity-theme";
+      const docEl = document.documentElement;
+      const allowedThemes = new Set(["light", "dark", "auto"]);
+      const systemDarkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+      function updateThemeButtons(activePreference) {
+        themeButtons.forEach((button) => {
+          const isActive = button.dataset.themeValue === activePreference;
+          button.classList.toggle("is-active", isActive);
+          button.setAttribute("aria-pressed", String(isActive));
+        });
+      }
+
+      function applyThemePreference(preference) {
+        const pref = allowedThemes.has(preference) ? preference : "auto";
+        docEl.setAttribute("data-theme-preference", pref);
+        const resolved =
+          pref === "auto"
+            ? systemDarkQuery.matches
+              ? "dark"
+              : "light"
+            : pref;
+        docEl.setAttribute("data-theme", resolved);
+        if (themeToggle) {
+          themeToggle.setAttribute("data-theme-resolved", resolved);
+        }
+        updateThemeButtons(pref);
+        return pref;
+      }
+
+      function getStoredThemePreference() {
+        try {
+          const stored = localStorage.getItem(themeStorageKey);
+          return stored && allowedThemes.has(stored) ? stored : null;
+        } catch (error) {
+          return null;
+        }
+      }
+
+      const initialPreference =
+        getStoredThemePreference() ??
+        docEl.getAttribute("data-theme-preference") ??
+        "auto";
+      applyThemePreference(initialPreference);
+
+      systemDarkQuery.addEventListener("change", () => {
+        if (docEl.getAttribute("data-theme-preference") === "auto") {
+          applyThemePreference("auto");
+        }
+      });
+
+      themeButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const value = button.dataset.themeValue;
+          const preference = allowedThemes.has(value) ? value : "auto";
+          try {
+            localStorage.setItem(themeStorageKey, preference);
+          } catch (error) {
+            // ignore storage failures
+          }
+          applyThemePreference(preference);
+        });
+      });
 
       function openMenu() {
         const topOffset = header.offsetHeight;


### PR DESCRIPTION
## Summary
- refactor global styling to use CSS custom properties that adapt between light and dark palettes
- add a footer appearance toggle with light/auto/dark modes that persist in local storage and respect system preferences
- wire the new theme logic into existing UI components so backgrounds, text, borders, and overlays stay legible in each theme

## Testing
- not run (static site project)


------
https://chatgpt.com/codex/tasks/task_e_68c98e099ecc8324926d805c26cb71ba