### PR TITLE
Improve light theme tertiary text contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,8 @@
         --color-text-primary: #0f172a;
         --color-text-secondary: #1f2937;
         --color-text-muted: #4b5563;
-        --color-text-subtle: #6b7280;
-        --color-text-tertiary: #94a3b8;
+        --color-text-subtle: #556070;
+        --color-text-tertiary: #4f6078;
         --color-accent: #4f46e5;
         --color-accent-hover: #4338ca;
         --color-accent-soft: #eef2ff;
@@ -121,8 +121,8 @@
         --color-text-primary: #0f172a;
         --color-text-secondary: #1f2937;
         --color-text-muted: #4b5563;
-        --color-text-subtle: #6b7280;
-        --color-text-tertiary: #94a3b8;
+        --color-text-subtle: #556070;
+        --color-text-tertiary: #4f6078;
         --color-accent: #4f46e5;
         --color-accent-hover: #4338ca;
         --color-accent-soft: #eef2ff;


### PR DESCRIPTION
## Summary
- darken the light theme subtle and tertiary text variables to improve contrast on tinted backgrounds
- keep the adjustments mirrored in both the root and explicit light-theme variable blocks

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3faf2209c83248677971c8a4b60b0