### PR TITLE
Improve timeline step spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,14 @@
         user-select: none;
         pointer-events: none;
       }
+      .timeline-step-content {
+        padding-block: clamp(2.5rem, 6vh, 4rem);
+      }
+      @media (min-width: 1024px) {
+        .timeline-step-content {
+          padding-block: clamp(3rem, 7vh, 4.5rem);
+        }
+      }
       #hero-after-wrapper {
         position: absolute;
         inset: 0;
@@ -921,16 +929,16 @@
               class="pointer-events-none absolute inset-y-0 left-[calc(1rem_-_0.0625rem)] w-[0.125rem] bg-indigo-600 lg:left-1/2 lg:-translate-x-1/2"
             ></div>
             <ol class="col-span-full">
-              <li class="relative min-h-screen">
+              <li class="relative min-h-screen pb-24 lg:pb-32">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="timeline-step sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex items-start justify-center lg:col-start-2">
                     <span
                       class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
-                  <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
+                  <div class="timeline-step-content col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
                     <h3 class="text-xl font-semibold text-indigo-600">
                       <span
                         class="block text-sm font-bold uppercase text-gray-500"
@@ -945,16 +953,16 @@
                   </div>
                 </div>
               </li>
-              <li class="relative min-h-screen">
+              <li class="relative min-h-screen pb-24 lg:pb-32">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="timeline-step sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex items-start justify-center lg:col-start-2">
                     <span
                       class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
-                  <div class="col-start-2 lg:col-start-3 lg:pl-8">
+                  <div class="timeline-step-content col-start-2 lg:col-start-3 lg:pl-8">
                     <h3 class="text-xl font-semibold text-indigo-600">
                       <span
                         class="block text-sm font-bold uppercase text-gray-500"
@@ -974,16 +982,16 @@
                   </div>
                 </div>
               </li>
-              <li class="relative min-h-screen">
+              <li class="relative min-h-screen pb-24 lg:pb-32">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="timeline-step sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex items-start justify-center lg:col-start-2">
                     <span
                       class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
-                  <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
+                  <div class="timeline-step-content col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
                     <h3 class="text-xl font-semibold text-indigo-600">
                       <span
                         class="block text-sm font-bold uppercase text-gray-500"
@@ -999,16 +1007,16 @@
                   </div>
                 </div>
               </li>
-              <li class="relative min-h-screen">
+              <li class="relative min-h-screen pb-24 lg:pb-32">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="timeline-step sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex items-start justify-center lg:col-start-2">
                     <span
                       class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
-                  <div class="col-start-2 lg:col-start-3 lg:pl-8">
+                  <div class="timeline-step-content col-start-2 lg:col-start-3 lg:pl-8">
                     <h3 class="text-xl font-semibold text-indigo-600">
                       <span
                         class="block text-sm font-bold uppercase text-gray-500"
@@ -1024,16 +1032,16 @@
                   </div>
                 </div>
               </li>
-              <li class="relative min-h-screen">
+              <li class="relative min-h-screen pb-24 lg:pb-32">
                 <div
-                  class="sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
+                  class="timeline-step sticky top-20 grid grid-cols-[2rem_1fr] lg:grid-cols-[1fr_2rem_1fr]"
                 >
                   <div class="flex items-start justify-center lg:col-start-2">
                     <span
                       class="mt-2 block h-4 w-4 rounded-full bg-indigo-600"
                     ></span>
                   </div>
-                  <div class="col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
+                  <div class="timeline-step-content col-start-2 lg:col-start-1 lg:pr-8 lg:text-right">
                     <h3 class="text-xl font-semibold text-indigo-600">
                       <span
                         class="block text-sm font-bold uppercase text-gray-500"


### PR DESCRIPTION
## Summary
- add consistent padding to timeline step content for left and right sticky panels
- increase bottom padding on each process step to create breathing room before the next section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a6d73c0483248acfabd458976395