### PR TITLE
Fix mobile nav CTA text color

### DIFF
--- a/index.html
+++ b/index.html
@@ -1745,23 +1745,38 @@
 
       const sectionEls = Array.from(document.querySelectorAll("section[id]"));
       const linkMap = {};
-      document
-        .querySelectorAll("#desktop-menu a, #mobile-menu a")
-        .forEach((link) => {
-          const id = link.getAttribute("href").slice(1);
-          (linkMap[id] ||= []).push(link);
-        });
+      const navLinks = document.querySelectorAll(
+        "#desktop-menu a, #mobile-menu a",
+      );
+
+      function shouldSkipHighlight(link) {
+        return link.classList.contains("bg-indigo-600");
+      }
+
+      navLinks.forEach((link) => {
+        if (shouldSkipHighlight(link)) {
+          return;
+        }
+        const id = link.getAttribute("href").slice(1);
+        (linkMap[id] ||= []).push(link);
+      });
       const activeClasses = ["text-gray-900", "font-semibold"];
       const inactiveClasses = ["text-gray-600"];
       function setActive(id) {
         Object.values(linkMap).forEach((links) =>
           links.forEach((l) => {
+            if (shouldSkipHighlight(l)) {
+              return;
+            }
             l.classList.remove(...activeClasses);
             l.classList.add(...inactiveClasses);
           }),
         );
         if (id && linkMap[id]) {
           linkMap[id].forEach((l) => {
+            if (shouldSkipHighlight(l)) {
+              return;
+            }
             l.classList.remove(...inactiveClasses);
             l.classList.add(...activeClasses);
           });


### PR DESCRIPTION
## Summary
- prevent the mobile navigation script from overriding the Request Demo button styling
- ensure the call-to-action retains its white text while other links continue to highlight on scroll

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d807ecd4e08324bacc2ced818a7794